### PR TITLE
Set TimeLimSec timelimit as integer

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -470,7 +470,7 @@ function MOI.get(model::Optimizer, param::MOI.RawParameter)
 end
 
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, limit::Real)
-    MOI.set(model, MOI.RawParameter("MAXTIME"), limit)
+    MOI.set(model, MOI.RawParameter("MAXTIME"), Int(floor(limit)))
     return
 end
 

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -470,7 +470,7 @@ function MOI.get(model::Optimizer, param::MOI.RawParameter)
 end
 
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, limit::Real)
-    MOI.set(model, MOI.RawParameter("MAXTIME"), Int(floor(limit)))
+    MOI.set(model, MOI.RawParameter("MAXTIME"), floor(Int, limit))
     return
 end
 

--- a/test/MathOptInterface/MOI_Wrapper.jl
+++ b/test/MathOptInterface/MOI_Wrapper.jl
@@ -30,6 +30,8 @@ const CONFIG_LOW_TOL = MOIT.TestConfig(atol = 1e-3, rtol = 1e-3)
     @test MOI.get(optimizer, MOI.RawParameter("logfile")) == ""
     optimizer = Xpress.Optimizer(OUTPUTLOG = 0, logfile = "output.log")
     @test MOI.get(optimizer, MOI.RawParameter("logfile")) == "output.log"
+    @test MOI.set(optimizer, MOI.TimeLimitSec(),100) === nothing
+    @test MOI.set(optimizer, MOI.TimeLimitSec(),3600.0) === nothing
 end
 
 @testset "SolverName" begin


### PR DESCRIPTION
Alpine sets time limit as float, and it looks like this is the only thing holding back Xpress support for Alpine.

https://github.com/lanl-ansi/Alpine.jl/pull/119