### PR TITLE
Change printing of `MOI.empty!`

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -302,7 +302,9 @@ function MOI.empty!(model::Optimizer)
     else
         MOI.set(model, MOI.RawParameter("OUTPUTLOG"), 1)
     end
+    Xpress.setcontrol!(model.inner, XPRS_ATTRIBUTES["OUTPUTLOG"], 0)
     Xpress.loadlp(model.inner)
+    Xpress.setcontrol!(model.inner, XPRS_ATTRIBUTES["OUTPUTLOG"], MOI.get(model, MOI.RawParameter("OUTPUTLOG")))
     model.objective_type = SCALAR_AFFINE
     model.is_feasibility = true
     empty!(model.variable_info)


### PR DESCRIPTION
Related to https://github.com/jump-dev/Xpress.jl/issues/101.

When an instance of `Xpress.Optimizer` is created, `MOI.empty!(model)` is called. When using the following syntax:

```julia
using JuMP
import Xpress

model = Model(with_optimizer(Xpress.Optimizer, OUTPUTLOG=0))
```

`Xpress.Optimizer()` is called with no keyword arguments. This means whatever values are hardcoded into the default values for `OUTPUTLOG` is used in the first pass. Which in this case is always `1`.

When `MOI.empty!(model)` is called, `Xpress.loadlp(model)` is called: https://github.com/jump-dev/Xpress.jl/blob/ea4fb32f701f697d3b52ad5528656e4508c73a0d/src/MOI/MOI_wrapper.jl#L311

This ends up printing the following to stdout:

```plaintext
Reading Problem
Problem Statistics
           0 (      0 spare) rows
           0 (      0 spare) structural columns
           0 (      0 spare) non-zero elements
Global Statistics
           0 entities        0 sets        0 set members
```

I think this output is not really useful, since when calling `empty!` the problem is always going to have 0 rows, 0 columns etc.

In this PR, I wrap `loadlp` with a call to disable `OUTPUTLOG` using `setcontrol!`.

```
    Xpress.setcontrol!(model.inner, XPRS_ATTRIBUTES["OUTPUTLOG"], 0)
    Xpress.loadlp(model.inner)
    Xpress.setcontrol!(model.inner, XPRS_ATTRIBUTES["OUTPUTLOG"], MOI.get(model, MOI.RawParameter("OUTPUTLOG")))
```

Alternatively, we can change defaults in `XpressProblem` and `Optimizer` to have `silent` as the default.
