### PR TITLE
Fix some installation issues on MacOS

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,7 +12,7 @@ function write_depsfile(path)
         path = replace(path, "\\" => "\\\\")
     end
     print(f,"""
-    const dlpath = \"$(path)\"
+    const xpressdlpath = \"$(path)\"
     """)
     close(f)
 end
@@ -50,4 +50,3 @@ elseif !found
     Note that Xpress must be obtained separately from fico.com.
     """)
 end
-

--- a/src/Xpress.jl
+++ b/src/Xpress.jl
@@ -45,7 +45,7 @@ module Xpress
     )
 
     function initialize()
-        lib = Libdl.dlopen(libxprs)
+        Libdl.dlopen(libxprs)
         userlic()
         init() # Call XPRSinit for initialization
         # free is not strictly necessary since destroyprob is called

--- a/src/Xpress.jl
+++ b/src/Xpress.jl
@@ -3,10 +3,10 @@ __precompile__()
 module Xpress
 
     using Libdl
-    const libxprs = string(Sys.iswindows() ? "" : "lib", "xprs", ".", Libdl.dlext)
 
     # Load in `deps.jl`, complaining if it does not exist
     const depsjl_path = joinpath(@__DIR__, "..", "deps", "deps.jl")
+
     if isfile(depsjl_path)
         include(depsjl_path)
     elseif !haskey(ENV, "XPRESS_JL_NO_DEPS_ERROR")
@@ -14,6 +14,8 @@ module Xpress
     else
         const xpressdlpath = ""
     end
+
+    const libxprs = joinpath(xpressdlpath, string(Sys.iswindows() ? "" : "lib", "xprs", ".", Libdl.dlext))
 
     ### imports
 
@@ -43,7 +45,7 @@ module Xpress
     )
 
     function initialize()
-        Libdl.dlopen(joinpath(dlpath, libxprs))
+        lib = Libdl.dlopen(libxprs)
         userlic()
         init() # Call XPRSinit for initialization
         # free is not strictly necessary since destroyprob is called

--- a/src/Xpress.jl
+++ b/src/Xpress.jl
@@ -12,7 +12,7 @@ module Xpress
     elseif !haskey(ENV, "XPRESS_JL_NO_DEPS_ERROR")
         error("XPRESS cannot be loaded. Please run Pkg.build(\"Xpress\").")
     else
-        const dlpath = ""
+        const xpressdlpath = ""
     end
 
     ### imports


### PR DESCRIPTION
1) `dlpath` is a function that exists in `Libdl`.

![Screen Shot 2020-11-19 at 4 13 06 PM](https://user-images.githubusercontent.com/1813121/99735644-33e9af80-2a82-11eb-8316-2a20798fad4e.png)

I've changed the name from `dlpath` to `xpressdlpath`. Other variable name suggestions welcome.

2) I think we should use the explicit path to `libxprs`. On MacOS, even though this function is called on initialize:

https://github.com/jump-dev/Xpress.jl/blob/master/src/Xpress.jl#L46

when the first call into the library is made, Julia is not able to locate the library.

```
$ julia --project -e "using Xpress"

[ Info: Xpress: Found license file /Users/USER/Applications/fico-xpress/xpressmp/bin/xpauth.xpr
ERROR: InitError: could not load library "libxprs.dylib"
dlopen(libxprs.dylib, 1): image not found
Stacktrace:
 [1] XPRSlicense(::Array{Int32,1}, ::String) at /Users/USER/gitrepos/Xpress.jl/src/lib.jl:54
 [2] license(::Array{Int32,1}, ::String) at /Users/USER/gitrepos/Xpress.jl/src/api.jl:142
 [3] userlic(; verbose::Bool, liccheck::typeof(Xpress.emptyliccheck), xpauth_path::String) at /Users/USER/gitrepos/Xpress.jl/src/license.jl:71
 [4] userlic at /Users/USER/gitrepos/Xpress.jl/src/license.jl:57 [inlined]
 [5] initialize at /Users/USER/gitrepos/Xpress.jl/src/Xpress.jl:47 [inlined]
 [6] __init__() at /Users/USER/gitrepos/Xpress.jl/src/Xpress.jl:61
 [7] _include_from_serialized(::String, ::Array{Any,1}) at ./loading.jl:697
 [8] _require_from_serialized(::String) at ./loading.jl:749
 [9] _require(::Base.PkgId) at ./loading.jl:1040
 [10] require(::Base.PkgId) at ./loading.jl:928
 [11] require(::Module, ::Symbol) at ./loading.jl:923
during initialization of module Xpress
```

If I change this to use the explicit path, it works as expected.

Resolves #109 