### PR TITLE
Breaking changes for MOI v0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-MathOptInterface = "~0.9.20"
+MathOptInterface = "0.10.0"
 julia = "1"
 
 [extras]

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -68,12 +68,12 @@ const SIMPLE_SCALAR_SETS = Union{
 }
 
 const INDICATOR_SETS = Union{
-    MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE,MOI.GreaterThan{Float64}},
-    MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO,MOI.GreaterThan{Float64}},
-    MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE,MOI.LessThan{Float64}},
-    MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO,MOI.LessThan{Float64}},
-    MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE,MOI.EqualTo{Float64}},
-    MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO,MOI.EqualTo{Float64}},
+    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.GreaterThan{Float64}},
+    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.GreaterThan{Float64}},
+    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{Float64}},
+    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.LessThan{Float64}},
+    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.EqualTo{Float64}},
+    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.EqualTo{Float64}},
 }
 
 mutable struct VariableInfo
@@ -86,7 +86,7 @@ mutable struct VariableInfo
     # Storage for constraint names associated with variables because Xpress can
     # only store names for variables and proper constraints. We can perform an
     # optimization and only store three strings for the constraint names
-    # because, at most, there can be three SingleVariable constraints, e.g.,
+    # because, at most, there can be three VariableIndex constraints, e.g.,
     # LessThan, GreaterThan, and Integer.
     lessthan_name::String
     greaterthan_interval_or_equalto_name::String
@@ -192,7 +192,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
 
     # A mapping from the MOI.VariableIndex to the Xpress column. VariableInfo
     # also stores some additional fields like what bounds have been added, the
-    # variable type, and the names of SingleVariable-in-Set constraints.
+    # variable type, and the names of VariableIndex-in-Set constraints.
     variable_info::CleverDicts.CleverDict{MOI.VariableIndex, VariableInfo}
 
     # An index that is incremented for each new constraint (regardless of type).
@@ -202,7 +202,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     last_constraint_index::Int
     # ScalarAffineFunction{Float64}-in-Set storage.
     # ScalarQuadraticFunction{Float64}-in-Set storage.
-    # VectorAffineFunction{Float64}-in-IndicatorSet storage.
+    # VectorAffineFunction{Float64}-in-Indicator storage.
     # VectorOfVariables-in-(R)SOC) storage.
     affine_constraint_info::Dict{Int, ConstraintInfo}
     # VectorOfVariables-in-Set storage.
@@ -260,7 +260,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         model.message_callback = nothing
 
         for (name, value) in kwargs
-            name = MOI.RawParameter(string(name))
+            name = MOI.RawOptimizerAttribute(string(name))
             model.params[name] = value
         end
 
@@ -284,18 +284,18 @@ function MOI.empty!(model::Optimizer)
         MOI.set(model, name, value)
     end
 
-    MOI.set(model, MOI.RawParameter("MPSNAMELENGTH"), 64)
-    MOI.set(model, MOI.RawParameter("CALLBACKFROMMASTERTHREAD"), 1)
+    MOI.set(model, MOI.RawOptimizerAttribute("MPSNAMELENGTH"), 64)
+    MOI.set(model, MOI.RawOptimizerAttribute("CALLBACKFROMMASTERTHREAD"), 1)
 
-    MOI.set(model, MOI.RawParameter("XPRESS_WARNING_WINDOWS"), model.show_warning)
+    MOI.set(model, MOI.RawOptimizerAttribute("XPRESS_WARNING_WINDOWS"), model.show_warning)
 
     # disable log caching previous state
     log_level = model.log_level
-    log_level != 0 && MOI.set(model, MOI.RawParameter("OUTPUTLOG"), 0)
+    log_level != 0 && MOI.set(model, MOI.RawOptimizerAttribute("OUTPUTLOG"), 0)
     # silently load a empty model - to avoid useless printing
     Xpress.loadlp(model.inner)
     # re-enable logging
-    log_level != 0 && MOI.set(model, MOI.RawParameter("OUTPUTLOG"), log_level)
+    log_level != 0 && MOI.set(model, MOI.RawOptimizerAttribute("OUTPUTLOG"), log_level)
 
     model.name = ""
     model.objective_type = SCALAR_AFFINE
@@ -419,7 +419,7 @@ function MOI.supports(
     ::Optimizer,
     ::MOI.ObjectiveFunction{F}
 ) where {F <: Union{
-    MOI.SingleVariable,
+    MOI.VariableIndex,
     MOI.ScalarAffineFunction{Float64},
     MOI.ScalarQuadraticFunction{Float64},
 }}
@@ -427,7 +427,7 @@ function MOI.supports(
 end
 
 function MOI.supports_constraint(
-    ::Optimizer, ::Type{MOI.SingleVariable}, ::Type{F}
+    ::Optimizer, ::Type{MOI.VariableIndex}, ::Type{F}
 ) where {F <: Union{
     MOI.EqualTo{Float64},
     MOI.LessThan{Float64},
@@ -498,14 +498,14 @@ MOI.supports(::Optimizer, ::MOI.Silent) = true
 MOI.supports(::Optimizer, ::MOI.NumberOfThreads) = true
 MOI.supports(::Optimizer, ::MOI.TimeLimitSec) = true
 MOI.supports(::Optimizer, ::MOI.ObjectiveSense) = true
-MOI.supports(::Optimizer, ::MOI.RawParameter) = true
+MOI.supports(::Optimizer, ::MOI.RawOptimizerAttribute) = true
 
-function MOI.set(model::Optimizer, param::MOI.RawParameter, value)
+function MOI.set(model::Optimizer, param::MOI.RawOptimizerAttribute, value)
     # Always store value in params dictionary when setting
     # This is because when calling `empty!` we create a new XpressProblem and
     # and want to set all the raw parameters and attributes again.
     model.params[param] = value
-    if param == MOI.RawParameter("logfile")
+    if param == MOI.RawOptimizerAttribute("logfile")
         if value == ""
             # disable log file
             Xpress.setlogfile(model.inner, C_NULL)
@@ -514,12 +514,12 @@ function MOI.set(model::Optimizer, param::MOI.RawParameter, value)
         end
         model.inner.logfile = value
         reset_message_callback(model)
-    elseif param == MOI.RawParameter("MOIWarnings")
+    elseif param == MOI.RawOptimizerAttribute("MOIWarnings")
         model.moi_warnings = value
-    elseif param == MOI.RawParameter("XPRESS_WARNING_WINDOWS")
+    elseif param == MOI.RawOptimizerAttribute("XPRESS_WARNING_WINDOWS")
         model.show_warning = value
         reset_message_callback(model)
-    elseif param == MOI.RawParameter("OUTPUTLOG")
+    elseif param == MOI.RawOptimizerAttribute("OUTPUTLOG")
         model.log_level = value
         Xpress.setcontrol!(model.inner, XPRS_ATTRIBUTES[param.name], value)
         reset_message_callback(model)
@@ -542,10 +542,10 @@ function reset_message_callback(model)
     end
 end
 
-function MOI.get(model::Optimizer, param::MOI.RawParameter)
-    if param == MOI.RawParameter("logfile")
+function MOI.get(model::Optimizer, param::MOI.RawOptimizerAttribute)
+    if param == MOI.RawOptimizerAttribute("logfile")
         return model.inner.logfile
-    elseif param == MOI.RawParameter("XPRESS_WARNING_WINDOWS")
+    elseif param == MOI.RawOptimizerAttribute("XPRESS_WARNING_WINDOWS")
         return model.show_warning
     else
         return Xpress.getcontrol(model.inner, XPRS_ATTRIBUTES[param.name])
@@ -555,22 +555,32 @@ end
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, limit::Real)
     # positive values would mean that its stops after `limit` seconds
     # iff there is already a MIP solution available.
-    MOI.set(model, MOI.RawParameter("MAXTIME"), -floor(Int32, limit))
+    MOI.set(model, MOI.RawOptimizerAttribute("MAXTIME"), -floor(Int32, limit))
     return
 end
 
 function MOI.get(model::Optimizer, ::MOI.TimeLimitSec)
-    return -MOI.get(model, MOI.RawParameter("MAXTIME"))
+    # MOI.attribute_value_type(MOI.TimeLimitSec()) = Union{Nothing, Float64}
+    return convert(Float64, -MOI.get(model, MOI.RawOptimizerAttribute("MAXTIME")))
 end
 
-MOI.Utilities.supports_default_copy_to(::Optimizer, ::Bool) = true
+MOI.supports_incremental_interface(::Optimizer) = true
 
 function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; kwargs...)
-    return MOI.Utilities.automatic_copy_to(dest, src; kwargs...)
+    return MOI.Utilities.default_copy_to(dest, src; kwargs...)
 end
 
 function MOI.get(model::Optimizer, ::MOI.ListOfVariableAttributesSet)
-    return MOI.AbstractVariableAttribute[MOI.VariableName()]
+    ret = MOI.AbstractVariableAttribute[]
+    found_name = any(!isempty(info.name) for info in values(model.variable_info))
+    found_start = any(info.start !== nothing for info in values(model.variable_info))
+    if found_name
+        push!(ret, MOI.VariableName())
+    end
+    if found_start
+        push!(ret, MOI.VariablePrimalStart())
+    end
+    return ret
 end
 
 function MOI.get(model::Optimizer, ::MOI.ListOfModelAttributesSet)
@@ -596,7 +606,7 @@ function _indices_and_coefficients(
     f::MOI.ScalarAffineFunction{Float64}
 )
     for (i, term) in enumerate(f.terms)
-        indices[i] = _info(model, term.variable_index).column
+        indices[i] = _info(model, term.variable).column
         coefficients[i] = term.coefficient
     end
     return indices, coefficients
@@ -622,7 +632,7 @@ function _indices_and_coefficients_indicator(
     i = 1
     for fi in f.terms
         if fi.output_index != 1
-            indices[i] = _info(model,fi.scalar_term.variable_index).column
+            indices[i] = _info(model,fi.scalar_term.variable).column
             coefficients[i] = fi.scalar_term.coefficient
             i += 1
         end
@@ -640,8 +650,8 @@ function _indices_and_coefficients(
     f::MOI.ScalarQuadraticFunction
 )
     for (i, term) in enumerate(f.quadratic_terms)
-        I[i] = _info(model, term.variable_index_1).column
-        J[i] = _info(model, term.variable_index_2).column
+        I[i] = _info(model, term.variable_1).column
+        J[i] = _info(model, term.variable_2).column
         V[i] =  term.coefficient
 
         # MOI    represents objective as 0.5 x' Q x
@@ -668,7 +678,7 @@ function _indices_and_coefficients(
 
     end
     for (i, term) in enumerate(f.affine_terms)
-        indices[i] = _info(model, term.variable_index).column
+        indices[i] = _info(model, term.variable).column
         coefficients[i] = term.coefficient
     end
     return
@@ -769,7 +779,7 @@ function MOI.delete(model::Optimizer, v::MOI.VariableIndex)
         end
     end
     model.name_to_variable = nothing
-    # We throw away name_to_constraint_index so we will rebuild SingleVariable
+    # We throw away name_to_constraint_index so we will rebuild VariableIndex
     # constraint names without v.
     model.name_to_constraint_index = nothing
     return
@@ -869,7 +879,7 @@ end
 
 function MOI.set(
     model::Optimizer, ::MOI.ObjectiveFunction{F}, f::F
-) where {F <: MOI.SingleVariable}
+) where {F <: MOI.VariableIndex}
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -879,12 +889,12 @@ function MOI.set(
     return
 end
 
-function MOI.get(model::Optimizer, ::MOI.ObjectiveFunction{MOI.SingleVariable})
+function MOI.get(model::Optimizer, ::MOI.ObjectiveFunction{MOI.VariableIndex})
     obj = MOI.get(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()
     )
-    return convert(MOI.SingleVariable, obj)
+    return convert(MOI.VariableIndex, obj)
 end
 
 function MOI.set(
@@ -899,7 +909,7 @@ function MOI.set(
     # are removed
     obj = zeros(Float64, num_vars)
     for term in f.terms
-        column = _info(model, term.variable_index).column
+        column = _info(model, term.variable).column
         obj[column] += term.coefficient
     end
     Xpress.chgobj(model.inner, collect(1:num_vars), obj)
@@ -983,7 +993,7 @@ function MOI.get(
     end
     affine_terms = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()).terms
     constant = Xpress.getdblattrib(model.inner, Xpress.Lib.XPRS_OBJRHS)
-    return MOI.ScalarQuadraticFunction(affine_terms, q_terms, constant)
+    return MOI.ScalarQuadraticFunction(q_terms, affine_terms, constant)
 end
 
 function MOI.modify(
@@ -996,11 +1006,11 @@ function MOI.modify(
 end
 
 ##
-##  SingleVariable-in-Set constraints.
+##  VariableIndex-in-Set constraints.
 ##
 
 function _info(
-    model::Optimizer, c::MOI.ConstraintIndex{MOI.SingleVariable, <:Any}
+    model::Optimizer, c::MOI.ConstraintIndex{MOI.VariableIndex, <:Any}
 )
     var_index = MOI.VariableIndex(c.value)
     if haskey(model.variable_info, var_index)
@@ -1011,7 +1021,7 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.LessThan{Float64}}
 )
     if haskey(model.variable_info, MOI.VariableIndex(c.value))
         info = _info(model, c)
@@ -1022,7 +1032,7 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{Float64}}
 )
     if haskey(model.variable_info, MOI.VariableIndex(c.value))
         info = _info(model, c)
@@ -1033,7 +1043,7 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Interval{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Interval{Float64}}
 )
     return haskey(model.variable_info, MOI.VariableIndex(c.value)) &&
         _info(model, c).bound == INTERVAL
@@ -1041,7 +1051,7 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.EqualTo{Float64}}
 )
     return haskey(model.variable_info, MOI.VariableIndex(c.value)) &&
         _info(model, c).bound == EQUAL_TO
@@ -1049,7 +1059,7 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.ZeroOne}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.ZeroOne}
 )
     return haskey(model.variable_info, MOI.VariableIndex(c.value)) &&
         _info(model, c).type == BINARY
@@ -1057,7 +1067,7 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Integer}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Integer}
 )
     return haskey(model.variable_info, MOI.VariableIndex(c.value)) &&
         _info(model, c).type == INTEGER
@@ -1065,7 +1075,7 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semicontinuous{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Semicontinuous{Float64}}
 )
     return haskey(model.variable_info, MOI.VariableIndex(c.value)) &&
         _info(model, c).type == SEMICONTINUOUS
@@ -1073,7 +1083,7 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semiinteger{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Semiinteger{Float64}}
 )
     return haskey(model.variable_info, MOI.VariableIndex(c.value)) &&
         _info(model, c).type == SEMIINTEGER
@@ -1081,17 +1091,17 @@ end
 
 function MOI.get(
     model::Optimizer, ::MOI.ConstraintFunction,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, <:Any}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, <:Any}
 )
     MOI.throw_if_not_valid(model, c)
-    return MOI.SingleVariable(MOI.VariableIndex(c.value))
+    return MOI.VariableIndex(c.value)
 end
 
 function MOI.set(
     model::Optimizer, ::MOI.ConstraintFunction,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, <:Any}, ::MOI.SingleVariable
+    c::MOI.ConstraintIndex{MOI.VariableIndex, <:Any}, ::MOI.VariableIndex
 )
-    return throw(MOI.SettingSingleVariableFunctionNotAllowed())
+    return throw(MOI.SettingVariableIndexNotAllowed())
 end
 
 _bounds(s::MOI.GreaterThan{Float64}) = (s.lower, nothing)
@@ -1147,9 +1157,9 @@ function _throw_if_existing_upper(
 end
 
 function MOI.add_constraint(
-    model::Optimizer, f::MOI.SingleVariable, s::S
+    model::Optimizer, f::MOI.VariableIndex, s::S
 ) where {S <: SCALAR_SETS}
-    info = _info(model, f.variable)
+    info = _info(model, f)
     if info.type == BINARY
         lower, upper = _bounds(s)
         if lower !== nothing
@@ -1169,83 +1179,61 @@ function MOI.add_constraint(
         end
     end
     if S <: MOI.LessThan{Float64}
-        _throw_if_existing_upper(info.bound, info.type, S, f.variable)
+        _throw_if_existing_upper(info.bound, info.type, S, f)
         info.bound = info.bound == GREATER_THAN ? LESS_AND_GREATER_THAN : LESS_THAN
     elseif S <: MOI.GreaterThan{Float64}
-        _throw_if_existing_lower(info.bound, info.type, S, f.variable)
+        _throw_if_existing_lower(info.bound, info.type, S, f)
         info.bound = info.bound == LESS_THAN ? LESS_AND_GREATER_THAN : GREATER_THAN
     elseif S <: MOI.EqualTo{Float64}
-        _throw_if_existing_lower(info.bound, info.type, S, f.variable)
-        _throw_if_existing_upper(info.bound, info.type, S, f.variable)
+        _throw_if_existing_lower(info.bound, info.type, S, f)
+        _throw_if_existing_upper(info.bound, info.type, S, f)
         info.bound = EQUAL_TO
     else
         @assert S <: MOI.Interval{Float64}
-        _throw_if_existing_lower(info.bound, info.type, S, f.variable)
-        _throw_if_existing_upper(info.bound, info.type, S, f.variable)
+        _throw_if_existing_lower(info.bound, info.type, S, f)
+        _throw_if_existing_upper(info.bound, info.type, S, f)
         info.bound = INTERVAL
     end
-    index = MOI.ConstraintIndex{MOI.SingleVariable, typeof(s)}(f.variable.value)
+    index = MOI.ConstraintIndex{MOI.VariableIndex, typeof(s)}(f.value)
     MOI.set(model, MOI.ConstraintSet(), index, s)
     return index
 end
 
 function MOI.add_constraints(
-    model::Optimizer, f::Vector{MOI.SingleVariable}, s::Vector{S}
+    model::Optimizer, f::Vector{MOI.VariableIndex}, s::Vector{S}
 ) where {S <: SCALAR_SETS}
     for fi in f
-        info = _info(model, fi.variable)
+        info = _info(model, fi)
         if S <: MOI.LessThan{Float64}
-            _throw_if_existing_upper(info.bound, info.type, S, fi.variable)
+            _throw_if_existing_upper(info.bound, info.type, S, fi)
             info.bound = info.bound == GREATER_THAN ? LESS_AND_GREATER_THAN : LESS_THAN
         elseif S <: MOI.GreaterThan{Float64}
-            _throw_if_existing_lower(info.bound, info.type, S, fi.variable)
+            _throw_if_existing_lower(info.bound, info.type, S, fi)
             info.bound = info.bound == LESS_THAN ? LESS_AND_GREATER_THAN : GREATER_THAN
         elseif S <: MOI.EqualTo{Float64}
-            _throw_if_existing_lower(info.bound, info.type, S, fi.variable)
-            _throw_if_existing_upper(info.bound, info.type, S, fi.variable)
+            _throw_if_existing_lower(info.bound, info.type, S, fi)
+            _throw_if_existing_upper(info.bound, info.type, S, fi)
             info.bound = EQUAL_TO
         else
             @assert S <: MOI.Interval{Float64}
-            _throw_if_existing_lower(info.bound, info.type, S, fi.variable)
-            _throw_if_existing_upper(info.bound, info.type, S, fi.variable)
+            _throw_if_existing_lower(info.bound, info.type, S, fi)
+            _throw_if_existing_upper(info.bound, info.type, S, fi)
             info.bound = INTERVAL
         end
     end
     indices = [
-        MOI.ConstraintIndex{MOI.SingleVariable, eltype(s)}(fi.variable.value)
+        MOI.ConstraintIndex{MOI.VariableIndex, eltype(s)}(fi.value)
         for fi in f
     ]
-    _set_bounds(model, indices, s)
-    return indices
-end
-
-function _set_bounds(
-    model::Optimizer,
-    indices::Vector{MOI.ConstraintIndex{MOI.SingleVariable, S}},
-    sets::Vector{S}
-) where {S}
-    columns, senses, values = Int[], Cchar[], Float64[]
-    for (c, s) in zip(indices, sets)
-        lower, upper = _bounds(s)
-        info = _info(model, c)
-        if lower !== nothing
-            push!(columns, info.column)
-            push!(senses, Cchar('L'))
-            push!(values, lower)
-        end
-        if upper !== nothing
-            push!(columns, info.column)
-            push!(senses, Cchar('U'))
-            push!(values, upper)
-        end
+    for (index, s) in zip(indices, s)
+        MOI.set(model, MOI.ConstraintSet(), index, s)
     end
-    Xpress.chgbounds(model.inner, columns, senses, values)
-    return
+    return indices
 end
 
 function MOI.delete(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.LessThan{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1353,7 +1341,7 @@ end
 
 function MOI.delete(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1375,7 +1363,7 @@ end
 
 function MOI.delete(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Interval{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Interval{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1394,7 +1382,7 @@ end
 
 function MOI.delete(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.EqualTo{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1414,7 +1402,7 @@ end
 function MOI.get(
     model::Optimizer,
     ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     lower = _get_variable_lower_bound(model, _info(model, c))
@@ -1424,7 +1412,7 @@ end
 function MOI.get(
     model::Optimizer,
     ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.LessThan{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     upper = _get_variable_upper_bound(model, _info(model, c))
@@ -1433,7 +1421,7 @@ end
 
 function MOI.get(
     model::Optimizer, ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.EqualTo{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     lower = _get_variable_lower_bound(model, _info(model, c))
@@ -1442,7 +1430,7 @@ end
 
 function MOI.get(
     model::Optimizer, ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Interval{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Interval{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1454,7 +1442,7 @@ end
 function MOI.set(
     model::Optimizer,
     ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, S}, s::S
+    c::MOI.ConstraintIndex{MOI.VariableIndex, S}, s::S
 ) where {S<:SCALAR_SETS}
     MOI.throw_if_not_valid(model, c)
     lower, upper = _bounds(s)
@@ -1471,9 +1459,9 @@ function MOI.set(
 end
 
 function MOI.add_constraint(
-    model::Optimizer, f::MOI.SingleVariable, ::MOI.ZeroOne
+    model::Optimizer, f::MOI.VariableIndex, ::MOI.ZeroOne
 )
-    info = _info(model, f.variable)
+    info = _info(model, f)
     info.previous_lower_bound = _get_variable_lower_bound(model, info)
     info.previous_upper_bound = _get_variable_upper_bound(model, info)
     lower, upper = info.previous_lower_bound, info.previous_upper_bound
@@ -1496,11 +1484,11 @@ function MOI.add_constraint(
     end
     Xpress.chgcoltype(model.inner, [info.column], Cchar['B'])
     info.type = BINARY
-    return MOI.ConstraintIndex{MOI.SingleVariable, MOI.ZeroOne}(f.variable.value)
+    return MOI.ConstraintIndex{MOI.VariableIndex, MOI.ZeroOne}(f.value)
 end
 
 function MOI.delete(
-    model::Optimizer, c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.ZeroOne}
+    model::Optimizer, c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.ZeroOne}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1516,23 +1504,23 @@ end
 function MOI.get(
     model::Optimizer,
     ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.ZeroOne}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.ZeroOne}
 )
     MOI.throw_if_not_valid(model, c)
     return MOI.ZeroOne()
 end
 
 function MOI.add_constraint(
-    model::Optimizer, f::MOI.SingleVariable, ::MOI.Integer
+    model::Optimizer, f::MOI.VariableIndex, ::MOI.Integer
 )
-    info = _info(model, f.variable)
+    info = _info(model, f)
     Xpress.chgcoltype(model.inner, [info.column], Cchar['I'])
     info.type = INTEGER
-    return MOI.ConstraintIndex{MOI.SingleVariable, MOI.Integer}(f.variable.value)
+    return MOI.ConstraintIndex{MOI.VariableIndex, MOI.Integer}(f.value)
 end
 
 function MOI.delete(
-    model::Optimizer, c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Integer}
+    model::Optimizer, c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Integer}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1546,28 +1534,28 @@ end
 function MOI.get(
     model::Optimizer,
     ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Integer}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Integer}
 )
     MOI.throw_if_not_valid(model, c)
     return MOI.Integer()
 end
 
 function MOI.add_constraint(
-    model::Optimizer, f::MOI.SingleVariable, s::MOI.Semicontinuous{Float64}
+    model::Optimizer, f::MOI.VariableIndex, s::MOI.Semicontinuous{Float64}
 )
-    info = _info(model, f.variable)
-    _throw_if_existing_lower(info.bound, info.type, typeof(s), f.variable)
-    _throw_if_existing_upper(info.bound, info.type, typeof(s), f.variable)
+    info = _info(model, f)
+    _throw_if_existing_lower(info.bound, info.type, typeof(s), f)
+    _throw_if_existing_upper(info.bound, info.type, typeof(s), f)
     Xpress.chgcoltype(model.inner, [info.column], Cchar['S'])
     _set_variable_semi_lower_bound(model, info, s.lower)
     _set_variable_upper_bound(model, info, s.upper)
     info.type = SEMICONTINUOUS
-    return MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semicontinuous{Float64}}(f.variable.value)
+    return MOI.ConstraintIndex{MOI.VariableIndex, MOI.Semicontinuous{Float64}}(f.value)
 end
 
 function MOI.delete(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semicontinuous{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Semicontinuous{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1584,7 +1572,7 @@ end
 function MOI.get(
     model::Optimizer,
     ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semicontinuous{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Semicontinuous{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1594,21 +1582,21 @@ function MOI.get(
 end
 
 function MOI.add_constraint(
-    model::Optimizer, f::MOI.SingleVariable, s::MOI.Semiinteger{Float64}
+    model::Optimizer, f::MOI.VariableIndex, s::MOI.Semiinteger{Float64}
 )
-    info = _info(model, f.variable)
-    _throw_if_existing_lower(info.bound, info.type, typeof(s), f.variable)
-    _throw_if_existing_upper(info.bound, info.type, typeof(s), f.variable)
+    info = _info(model, f)
+    _throw_if_existing_lower(info.bound, info.type, typeof(s), f)
+    _throw_if_existing_upper(info.bound, info.type, typeof(s), f)
     Xpress.chgcoltype(model.inner, [info.column], Cchar['R'])
     _set_variable_semi_lower_bound(model, info, s.lower)
     _set_variable_upper_bound(model, info, s.upper)
     info.type = SEMIINTEGER
-    return MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semiinteger{Float64}}(f.variable.value)
+    return MOI.ConstraintIndex{MOI.VariableIndex, MOI.Semiinteger{Float64}}(f.value)
 end
 
 function MOI.delete(
     model::Optimizer,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semiinteger{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Semiinteger{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1625,7 +1613,7 @@ end
 function MOI.get(
     model::Optimizer,
     ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semiinteger{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Semiinteger{Float64}}
 )
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1637,7 +1625,7 @@ end
 function MOI.get(
     model::Optimizer,
     ::MOI.ConstraintName,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, S}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, S}
 ) where {S}
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -1654,7 +1642,7 @@ end
 function MOI.set(
     model::Optimizer,
     ::MOI.ConstraintName,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, S}, name::String
+    c::MOI.ConstraintIndex{MOI.VariableIndex, S}, name::String
 ) where {S}
     MOI.throw_if_not_valid(model, c)
     info = _info(model, c)
@@ -2003,7 +1991,7 @@ function _rebuild_name_to_constraint_index_variables(model::Optimizer)
                 model.name_to_constraint_index[constraint_name] = nothing
             else
                 model.name_to_constraint_index[constraint_name] =
-                    MOI.ConstraintIndex{MOI.SingleVariable, S}(key.value)
+                    MOI.ConstraintIndex{MOI.VariableIndex, S}(key.value)
             end
         end
     end
@@ -2017,7 +2005,7 @@ end
 function MOI.get(
     model::Optimizer,
     ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.IndicatorSet{A,S}}
+    c::MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.Indicator{A,S}}
 ) where {A, S <: SCALAR_SETS}
     # rhs = Vector{Cdouble}(undef, 1)
     # info = _info(model, c)
@@ -2025,7 +2013,7 @@ function MOI.get(
     # set_cte = MOI.constant(info.set.set)
     # # a^T x + b <= c ===> a^T <= c - b
     # Xpress.getrhs!(model.inner, rhs, row, row)
-    # return MOI.IndicatorSet{A}(S(rhs[1]))
+    # return MOI.Indicator{A}(S(rhs[1]))
     return _info(model, c).set
 end
 
@@ -2034,7 +2022,7 @@ function _indicator_variable(f::MOI.VectorAffineFunction)
     changes = 0
     for fi in f.terms
         if fi.output_index == 1
-            value = fi.scalar_term.variable_index.value
+            value = fi.scalar_term.variable.value
             changes += 1
         end
     end
@@ -2048,7 +2036,7 @@ indicator_activation(::Type{Val{MOI.ACTIVATE_ON_ZERO}}) = Cint(-1)
 indicator_activation(::Type{Val{MOI.ACTIVATE_ON_ONE}}) = Cint(1)
 
 function MOI.add_constraint(
-    model::Optimizer, f::MOI.VectorAffineFunction{T}, is::MOI.IndicatorSet{A, LT}) where {T<:Real, LT<:Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo},A}
+    model::Optimizer, f::MOI.VectorAffineFunction{T}, is::MOI.Indicator{A, LT}) where {T<:Real, LT<:Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo},A}
     con_value = _indicator_variable(f)
     model.last_constraint_index += 1
     model.affine_constraint_info[model.last_constraint_index] =
@@ -2146,7 +2134,7 @@ function MOI.get(
             )
         )
     end
-    return MOI.ScalarQuadraticFunction(affine_terms, quadratic_terms, 0.0)
+    return MOI.ScalarQuadraticFunction(quadratic_terms, affine_terms, 0.0)
 end
 
 ###
@@ -2527,7 +2515,7 @@ end
 
 function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
     _throw_if_optimize_in_progress(model, attr)
-    if attr.N != 1
+    if attr.result_index != 1
         return MOI.NO_SOLUTION
     end
     term_stat = MOI.get(model, MOI.TerminationStatus())
@@ -2569,7 +2557,7 @@ end
 
 function MOI.get(model::Optimizer, attr::MOI.DualStatus)
     _throw_if_optimize_in_progress(model, attr)
-    if attr.N != 1
+    if attr.result_index != 1
         return MOI.NO_SOLUTION
     elseif is_mip(model)
         return MOI.NO_SOLUTION
@@ -2594,7 +2582,7 @@ end
 
 function MOI.get(
     model::Optimizer, attr::MOI.ConstraintPrimal,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, <:Any}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, <:Any}
 )
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)
@@ -2652,7 +2640,7 @@ end
 
 function MOI.get(
     model::Optimizer, attr::MOI.ConstraintDual,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.LessThan{Float64}}
 )
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)
@@ -2683,7 +2671,7 @@ end
 
 function MOI.get(
     model::Optimizer, attr::MOI.ConstraintDual,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{Float64}}
 )
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)
@@ -2714,7 +2702,7 @@ end
 
 function MOI.get(
     model::Optimizer, attr::MOI.ConstraintDual,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.EqualTo{Float64}}
 )
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)
@@ -2728,7 +2716,7 @@ end
 
 function MOI.get(
     model::Optimizer, attr::MOI.ConstraintDual,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, MOI.Interval{Float64}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Interval{Float64}}
 )
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)
@@ -2782,7 +2770,7 @@ function MOI.get(model::Optimizer, attr::MOI.ObjectiveBound)
     end
 end
 
-function MOI.get(model::Optimizer, attr::MOI.SolveTime)
+function MOI.get(model::Optimizer, attr::MOI.SolveTimeSec)
     _throw_if_optimize_in_progress(model, attr)
     return model.cached_solution.solve_time
 end
@@ -2834,16 +2822,16 @@ function MOI.get(model::Optimizer, ::MOI.Silent)
 end
 
 function MOI.set(model::Optimizer, ::MOI.Silent, flag::Bool)
-    MOI.set(model, MOI.RawParameter("OUTPUTLOG"), ifelse(flag, 0, 1))
+    MOI.set(model, MOI.RawOptimizerAttribute("OUTPUTLOG"), ifelse(flag, 0, 1))
     return
 end
 
 function MOI.get(model::Optimizer, ::MOI.NumberOfThreads)
-    return Int(MOI.get(model, MOI.RawParameter("THREADS")))
+    return Int(MOI.get(model, MOI.RawOptimizerAttribute("THREADS")))
 end
 
 function MOI.set(model::Optimizer, ::MOI.NumberOfThreads, x::Int)
-    return MOI.set(model, MOI.RawParameter("THREADS"), x)
+    return MOI.set(model, MOI.RawOptimizerAttribute("THREADS"), x)
 end
 
 function MOI.get(model::Optimizer, ::MOI.Name)
@@ -2903,12 +2891,12 @@ _type_enums(::Type{<:MOI.Semiinteger}) = (SEMIINTEGER,)
 _type_enums(::Any) = (nothing,)
 
 function MOI.get(
-    model::Optimizer, ::MOI.ListOfConstraintIndices{MOI.SingleVariable, S}
+    model::Optimizer, ::MOI.ListOfConstraintIndices{MOI.VariableIndex, S}
 ) where {S}
-    indices = MOI.ConstraintIndex{MOI.SingleVariable, S}[]
+    indices = MOI.ConstraintIndex{MOI.VariableIndex, S}[]
     for (key, info) in model.variable_info
         if info.bound in _bound_enums(S) || info.type in _type_enums(S)
-            push!(indices, MOI.ConstraintIndex{MOI.SingleVariable, S}(key.value))
+            push!(indices, MOI.ConstraintIndex{MOI.VariableIndex, S}(key.value))
         end
     end
     return sort!(indices, by = x -> x.value)
@@ -2944,31 +2932,31 @@ function MOI.get(
     return sort!(indices, by = x -> x.value)
 end
 
-function MOI.get(model::Optimizer, ::MOI.ListOfConstraints)
-    constraints = Set{Tuple{DataType, DataType}}()
+function MOI.get(model::Optimizer, ::MOI.ListOfConstraintTypesPresent)
+    constraints = Set{Tuple{Type, Type}}()
     for info in values(model.variable_info)
         if info.bound == NONE
         elseif info.bound == LESS_THAN
-            push!(constraints, (MOI.SingleVariable, MOI.LessThan{Float64}))
+            push!(constraints, (MOI.VariableIndex, MOI.LessThan{Float64}))
         elseif info.bound == GREATER_THAN
-            push!(constraints, (MOI.SingleVariable, MOI.GreaterThan{Float64}))
+            push!(constraints, (MOI.VariableIndex, MOI.GreaterThan{Float64}))
         elseif info.bound == LESS_AND_GREATER_THAN
-            push!(constraints, (MOI.SingleVariable, MOI.LessThan{Float64}))
-            push!(constraints, (MOI.SingleVariable, MOI.GreaterThan{Float64}))
+            push!(constraints, (MOI.VariableIndex, MOI.LessThan{Float64}))
+            push!(constraints, (MOI.VariableIndex, MOI.GreaterThan{Float64}))
         elseif info.bound == EQUAL_TO
-            push!(constraints, (MOI.SingleVariable, MOI.EqualTo{Float64}))
+            push!(constraints, (MOI.VariableIndex, MOI.EqualTo{Float64}))
         elseif info.bound == INTERVAL
-            push!(constraints, (MOI.SingleVariable, MOI.Interval{Float64}))
+            push!(constraints, (MOI.VariableIndex, MOI.Interval{Float64}))
         end
         if info.type == CONTINUOUS
         elseif info.type == BINARY
-            push!(constraints, (MOI.SingleVariable, MOI.ZeroOne))
+            push!(constraints, (MOI.VariableIndex, MOI.ZeroOne))
         elseif info.type == INTEGER
-            push!(constraints, (MOI.SingleVariable, MOI.Integer))
+            push!(constraints, (MOI.VariableIndex, MOI.Integer))
         elseif info.type == SEMICONTINUOUS
-            push!(constraints, (MOI.SingleVariable, MOI.Semicontinuous{Float64}))
+            push!(constraints, (MOI.VariableIndex, MOI.Semicontinuous{Float64}))
         elseif info.type == SEMIINTEGER
-            push!(constraints, (MOI.SingleVariable, MOI.Semiinteger{Float64}))
+            push!(constraints, (MOI.VariableIndex, MOI.Semiinteger{Float64}))
         end
     end
     for info in values(model.affine_constraint_info)
@@ -2996,7 +2984,7 @@ function MOI.get(model::Optimizer, ::MOI.ObjectiveFunctionType)
     if model.is_feasibility
         return nothing
     elseif model.objective_type == SINGLE_VARIABLE
-        return MOI.SingleVariable
+        return MOI.VariableIndex
     elseif model.objective_type == SCALAR_AFFINE
         return MOI.ScalarAffineFunction{Float64}
     else
@@ -3051,7 +3039,7 @@ function _replace_with_matching_sparsity!(
     replacement::MOI.ScalarAffineFunction, row::Int
 )
     for term in replacement.terms
-        col = _info(model, term.variable_index).column
+        col = _info(model, term.variable).column
         Xpress.chgcoef(
             model.inner, row, col, MOI.coefficient(term)
         )
@@ -3084,13 +3072,13 @@ function _replace_with_different_sparsity!(
 )
     # First, zero out the old constraint function terms.
     for term in previous.terms
-        col = _info(model, term.variable_index).column
+        col = _info(model, term.variable).column
         Xpress.chgcoef(model.inner, row, col, 0.0)
     end
 
     # Next, set the new constraint function terms.
     for term in previous.terms
-        col = _info(model, term.variable_index).column
+        col = _info(model, term.variable).column
         Xpress.chgcoef(model.inner, row, col, MOI.coefficient(term))
     end
     return
@@ -3186,10 +3174,10 @@ function MOI.get(
 end
 
 function MOI.get(
-    model::Optimizer, ::MOI.ConstraintBasisStatus,
-    c::MOI.ConstraintIndex{MOI.SingleVariable, S}
-) where {S <: SCALAR_SETS}
-    column = _info(model, c).column
+    model::Optimizer, ::MOI.VariableBasisStatus,
+    x::MOI.VariableIndex
+)
+    column = _info(model, x).column
     basis_status = model.basis_status
     if basis_status == nothing
         _generate_basis_status(model::Optimizer)
@@ -3200,21 +3188,9 @@ function MOI.get(
     if vbasis == 1
         return MOI.BASIC
     elseif vbasis == 0
-        if S <: MOI.LessThan
-            return MOI.BASIC
-        elseif !(S <: MOI.Interval)
-            return MOI.NONBASIC
-        else
-            return MOI.NONBASIC_AT_LOWER
-        end
+        return MOI.NONBASIC_AT_LOWER
     elseif vbasis == 2
-        if S <: MOI.GreaterThan
-            return MOI.BASIC
-        elseif !(S <: MOI.Interval)
-            return MOI.NONBASIC
-        else
-            return MOI.NONBASIC_AT_UPPER
-        end
+        return MOI.NONBASIC_AT_UPPER
     elseif vbasis == 3
         return MOI.SUPER_BASIC
     else
@@ -3615,7 +3591,7 @@ function MOI.get(model::Optimizer, ::MOI.ConstraintConflictStatus, index::MOI.Co
     return (_info(model, index).row - 1) in model.conflict.miisrow ? MOI.IN_CONFLICT : MOI.NOT_IN_CONFLICT
 end
 
-function MOI.get(model::Optimizer, ::MOI.ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:Union{MOI.LessThan, MOI.GreaterThan, MOI.EqualTo}})
+function MOI.get(model::Optimizer, ::MOI.ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.VariableIndex, <:Union{MOI.LessThan, MOI.GreaterThan, MOI.EqualTo}})
     _ensure_conflict_computed(model)
     return (_info(model, index).column) in model.conflict.miiscol ? MOI.IN_CONFLICT : MOI.NOT_IN_CONFLICT
 end
@@ -3623,7 +3599,7 @@ end
 function MOI.supports(
     ::Optimizer,
     ::MOI.ConstraintConflictStatus,
-    ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, <:SCALAR_SETS}}
+    ::Type{MOI.ConstraintIndex{<:MOI.VariableIndex, <:SCALAR_SETS}}
 )
     return true
 end

--- a/test/MathOptInterface/MOI_Wrapper.jl
+++ b/test/MathOptInterface/MOI_Wrapper.jl
@@ -1,253 +1,70 @@
+module TestMOIWrapper
+
 using Xpress
 using MathOptInterface
 using Test
 
 const MOI = MathOptInterface
-const MOIT = MathOptInterface.Test
 
-const MOIT = MOI.Test
-const MOIU = MOI.Utilities
-
-const OPTIMIZER = Xpress.Optimizer(OUTPUTLOG = 0)
-const OPTIMIZER_2 = Xpress.Optimizer(OUTPUTLOG = 0)
-
-# Xpress can only obtain primal and dual rays without presolve. Check more on
-# https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/HTML/XPRSgetprimalray.html
-
-const BRIDGED_OPTIMIZER = MOI.Bridges.full_bridge_optimizer(
-    OPTIMIZER, Float64)
-const BRIDGED_CERTIFICATE_OPTIMIZER =
-    MOI.Bridges.full_bridge_optimizer(
-        Xpress.Optimizer(OUTPUTLOG = 0, PRESOLVE = 0), Float64)
-
-const CONFIG = MOIT.TestConfig()
-const CONFIG_LOW_TOL = MOIT.TestConfig(atol = 1e-3, rtol = 1e-3)
-
-@testset "MOI interface" begin
-    optimizer = Xpress.Optimizer(OUTPUTLOG = 0)
-    @test MOI.get(optimizer, MOI.RawParameter("logfile")) == ""
-    optimizer = Xpress.Optimizer(OUTPUTLOG = 0, logfile = "output.log")
-    @test MOI.get(optimizer, MOI.RawParameter("logfile")) == "output.log"
-    @test MOI.set(optimizer, MOI.TimeLimitSec(),100) === nothing
-    @test MOI.set(optimizer, MOI.TimeLimitSec(),3600.0) === nothing
-end
-
-@testset "SolverName" begin
-    @test MOI.get(OPTIMIZER, MOI.SolverName()) == "Xpress"
-end
-
-@testset "supports_default_copy_to" begin
-    @test MOIU.supports_default_copy_to(OPTIMIZER, true)
-end
-
-@testset "Unit Tests Constraints" begin
-    MOIT.basic_constraint_tests(OPTIMIZER, CONFIG)
-end
-
-@testset "Unit Tests" begin
-    MOIT.unittest(BRIDGED_OPTIMIZER, CONFIG, #= excludes =# String[
-        # TODO: fix errors
-        # does not work with caching optimizer
-        "delete_soc_variables",
-
-        # These tests fail due to tolerance issues; tested below.
-        "solve_qcp_edge_cases",
-        "solve_qp_edge_cases",
-        "solve_qp_zero_offdiag",
-            
-        # These tests require extra parameters to obtain certificates.
-        "solve_farkas_equalto_upper",
-        "solve_farkas_equalto_lower",
-        "solve_farkas_lessthan",
-        "solve_farkas_greaterthan",
-        "solve_farkas_interval_upper",
-        "solve_farkas_interval_lower",
-        "solve_farkas_variable_lessthan",
-        "solve_farkas_variable_lessthan_max",
-       ],
-    )
-    # certificates
-    MOIT.solve_farkas_equalto_upper(BRIDGED_CERTIFICATE_OPTIMIZER,CONFIG)
-    MOIT.solve_farkas_equalto_lower(BRIDGED_CERTIFICATE_OPTIMIZER,CONFIG)
-    MOIT.solve_farkas_lessthan(BRIDGED_CERTIFICATE_OPTIMIZER,CONFIG)
-    MOIT.solve_farkas_greaterthan(BRIDGED_CERTIFICATE_OPTIMIZER,CONFIG)
-    MOIT.solve_farkas_interval_upper(BRIDGED_CERTIFICATE_OPTIMIZER,CONFIG)
-    MOIT.solve_farkas_interval_lower(BRIDGED_CERTIFICATE_OPTIMIZER,CONFIG)
-    MOIT.solve_farkas_variable_lessthan(BRIDGED_CERTIFICATE_OPTIMIZER,CONFIG)
-    MOIT.solve_farkas_variable_lessthan_max(BRIDGED_CERTIFICATE_OPTIMIZER,CONFIG)
-    # tolerance
-    MOIT.solve_qcp_edge_cases(BRIDGED_OPTIMIZER, CONFIG_LOW_TOL)
-    MOIT.solve_qp_edge_cases(BRIDGED_OPTIMIZER, CONFIG_LOW_TOL)
-    MOIT.solve_qp_zero_offdiag(BRIDGED_OPTIMIZER, CONFIG_LOW_TOL)
-    # MOIT.delete_soc_variables(OPTIMIZER, CONFIG_LOW_TOL)
-    MOIT.modificationtest(BRIDGED_OPTIMIZER, CONFIG)
-end
-
-@testset "Linear tests" begin
-    MOIT.contlineartest(
-        BRIDGED_OPTIMIZER,
-        MOIT.TestConfig(
-            basis = true,
-            infeas_certificates = false
-        ), [
-            # These tests require extra parameters to obtain certificates.
-            "linear8a", "linear8b", "linear8c","linear12",
-        ]
-    )
-    MOIT.linear8atest(BRIDGED_CERTIFICATE_OPTIMIZER, CONFIG)
-    MOIT.linear8btest(BRIDGED_CERTIFICATE_OPTIMIZER, CONFIG)
-    MOIT.linear8ctest(BRIDGED_CERTIFICATE_OPTIMIZER, CONFIG)
-    MOIT.linear12test(BRIDGED_CERTIFICATE_OPTIMIZER, CONFIG)
-end
-
-@testset "Quadratic tests" begin
-    MOIT.contquadratictest(
-        BRIDGED_OPTIMIZER,
-        MOIT.TestConfig(atol = 1e-3, rtol = 1e-3),
-        [
-            # Xpress does NOT support ncqcp.
-            "ncqcp",
-        ]
-    )
-end
-
-@testset "Conic tests" begin
-    MOIT.lintest(BRIDGED_OPTIMIZER, CONFIG, [
-        # These tests require extra parameters to obtain certificates.
-        "lin3", "lin4"
-    ])
-    MOIT.lin3test(BRIDGED_CERTIFICATE_OPTIMIZER, CONFIG)
-    MOIT.lin4test(BRIDGED_CERTIFICATE_OPTIMIZER, CONFIG)
-    MOIT.soctest(BRIDGED_OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3), ["soc3"])
-    MOIT.soc3test(
-        BRIDGED_OPTIMIZER,
-        MOIT.TestConfig(duals = false, infeas_certificates = false, atol = 1e-3)
-    )
-    MOIT.rsoctest(BRIDGED_OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3), ["rotatedsoc3"])
-    MOIT.rotatedsoc3test(BRIDGED_OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-2))
-    MOIT.geomeantest(BRIDGED_OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3))
-end
-
-@testset "Integer Linear tests" begin
-    MOIT.intlineartest(BRIDGED_OPTIMIZER, CONFIG)
-end
-
-@testset "ModelLike tests" begin
-    @testset "default_objective_test" begin
-        MOIT.default_objective_test(OPTIMIZER)
-    end
-
-    @testset "default_status_test" begin
-        MOIT.default_status_test(OPTIMIZER)
-    end
-
-    @testset "nametest" begin
-        MOIT.nametest(BRIDGED_OPTIMIZER)
-    end
-
-    @testset "validtest" begin
-        MOIT.validtest(OPTIMIZER)
-    end
-
-    @testset "emptytest" begin
-        MOIT.emptytest(BRIDGED_OPTIMIZER)
-    end
-
-    @testset "orderedindicestest" begin
-        MOIT.orderedindicestest(OPTIMIZER)
-    end
-
-    @testset "copytest" begin
-        BRIDGED_OPTIMIZER_2 = MOI.Bridges.full_bridge_optimizer(
-            OPTIMIZER_2, Float64
-        )
-        MOIT.copytest(BRIDGED_OPTIMIZER, BRIDGED_OPTIMIZER_2)
-    end
-end
-
-@testset "IIS tests" begin
-    for warning in [true, false]
-        @testset "Variable bounds" begin
-            model = Xpress.Optimizer(OUTPUTLOG = 0, DEFAULTALG = 3, PRESOLVE = 0)
-            MOI.set(model, MOI.RawParameter("MOIWarnings"), warning)
-            x = MOI.add_variable(model)
-            c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
-            c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
-
-            # Getting the results before the conflict refiner has been called must return an error.
-            @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
-            @test_throws ErrorException MOI.get(model, MOI.ConstraintConflictStatus(), c1)
-
-            # Once it's called, no problem.
-            MOI.compute_conflict!(model)
-            @test MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
-            @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.IN_CONFLICT
-            @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.IN_CONFLICT
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
         end
     end
+end
 
-    @testset "Two conflicting constraints (GreaterThan, LessThan)" begin
-        model = Xpress.Optimizer(OUTPUTLOG = 0)
+function test_runtests()
+    optimizer = Xpress.Optimizer(OUTPUTLOG = 0)
+    model = MOI.Bridges.full_bridge_optimizer(optimizer, Float64)
+    MOI.set(model, MOI.Silent(), true)
+    MOI.Test.runtests(
+        model,
+        MOI.Test.Config(atol = 1e-3, rtol = 1e-3),
+        exclude = String[
+            "test_objective_set_via_modify",
+            "test_model_ListOfConstraintAttributesSet",
+            "test_solve_conflict_feasible",
+            "test_objective_get_ObjectiveFunction_ScalarAffineFunction",
+            "_SecondOrderCone_",
+            "test_constraint_PrimalStart_DualStart_SecondOrderCone",
+            "_RotatedSecondOrderCone_",
+            "_GeometricMeanCone_",
+            # It seems that Xpress cannot handle nonconvex quadratic constraint
+            "test_quadratic_nonconvex_",
+            # TODO: conflict tests should be investigated further
+            "test_solve_conflict_"
+        ],
+    )
+
+    optimizer_no_presolve = Xpress.Optimizer(OUTPUTLOG = 0, PRESOLVE = 0)
+    model = MOI.Bridges.full_bridge_optimizer(optimizer_no_presolve, Float64)
+    MOI.Test.runtests(
+        model,
+        MOI.Test.Config(
+            atol = 1e-3,
+            rtol = 1e-3,
+            exclude = Any[MOI.ConstraintDual, MOI.DualObjectiveValue],
+        ),
+        include = String[
+            "_SecondOrderCone_",
+            "test_constraint_PrimalStart_DualStart_SecondOrderCone",
+            "_RotatedSecondOrderCone_",
+            "_GeometricMeanCone_"
+        ]
+    )
+    return
+end
+
+function test_IIS_Variable_bounds()
+    for warning in [true, false]
+        model = Xpress.Optimizer(OUTPUTLOG = 0, DEFAULTALG = 3, PRESOLVE = 0)
+        MOI.set(model, MOI.RawOptimizerAttribute("MOIWarnings"), warning)
         x = MOI.add_variable(model)
-        y = MOI.add_variable(model)
-        b1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(0.0))
-        b2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [y]), 0.0), MOI.GreaterThan(0.0))
-        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
-        c1 = MOI.add_constraint(model, cf1, MOI.LessThan(-1.0))
-        cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]), 0.0)
-        c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
-
-        # Getting the results before the conflict refiner has been called must return an error.
-        @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
-        @test_throws ErrorException MOI.get(model, MOI.ConstraintConflictStatus(), c1)
-
-        # Once it's called, no problem.
-        # Two possible IISes: b1, b2, c1 OR b2, c1, c2
-        MOI.compute_conflict!(model)
-        @test MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), b1) in [MOI.IN_CONFLICT, MOI.NOT_IN_CONFLICT]
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), b2) == MOI.IN_CONFLICT
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.IN_CONFLICT
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) in [MOI.IN_CONFLICT, MOI.NOT_IN_CONFLICT]
-    end
-
-    @testset "Two conflicting constraints (EqualTo)" begin
-        model = Xpress.Optimizer(OUTPUTLOG = 0)
-        x = MOI.add_variable(model)
-        y = MOI.add_variable(model)
-        b1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(0.0))
-        b2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [y]), 0.0), MOI.GreaterThan(0.0))
-        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
-        c1 = MOI.add_constraint(model, cf1, MOI.EqualTo(-1.0))
-        cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]), 0.0)
-        c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
-
-        # Getting the results before the conflict refiner has been called must return an error.
-        @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
-        @test_throws ErrorException MOI.get(model, MOI.ConstraintConflictStatus(), c1)
-
-        # Once it's called, no problem.
-        # Two possible IISes: b1, b2, c1 OR b2, c1, c2
-        MOI.compute_conflict!(model)
-        @test MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), b1) in [MOI.IN_CONFLICT, MOI.NOT_IN_CONFLICT]
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), b2) == MOI.IN_CONFLICT
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.IN_CONFLICT
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) in [MOI.IN_CONFLICT, MOI.NOT_IN_CONFLICT]
-    end
-
-    @testset "Variables outside conflict" begin
-        model = Xpress.Optimizer(OUTPUTLOG = 0)
-        x = MOI.add_variable(model)
-        y = MOI.add_variable(model)
-        z = MOI.add_variable(model)
-        b1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(0.0))
-        b2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [y]), 0.0), MOI.GreaterThan(0.0))
-        b3 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [z]), 0.0), MOI.GreaterThan(0.0))
-        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
-        c1 = MOI.add_constraint(model, cf1, MOI.LessThan(-1.0))
-        cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0, 1.0], [x, y, z]), 0.0)
-        c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+        c1 = MOI.add_constraint(model, x, MOI.GreaterThan(2.0))
+        c2 = MOI.add_constraint(model, x, MOI.LessThan(1.0))
 
         # Getting the results before the conflict refiner has been called must return an error.
         @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
@@ -256,42 +73,116 @@ end
         # Once it's called, no problem.
         MOI.compute_conflict!(model)
         @test MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), b1) == MOI.IN_CONFLICT
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), b2) == MOI.IN_CONFLICT
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), b3) == MOI.NOT_IN_CONFLICT
         @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.IN_CONFLICT
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.NOT_IN_CONFLICT
-    end
-
-    @testset "No conflict" begin
-        model = Xpress.Optimizer(OUTPUTLOG = 0)
-        x = MOI.add_variable(model)
-        c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(1.0))
-        c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.LessThan(2.0))
-
-        # Getting the results before the conflict refiner has been called must return an error.
-        @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
-        @test_throws ErrorException MOI.get(model, MOI.ConstraintConflictStatus(), c1)
-
-        # Once it's called, no problem.
-        MOI.compute_conflict!(model)
-        @test MOI.get(model, MOI.ConflictStatus()) == MOI.NO_CONFLICT_FOUND
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.NOT_IN_CONFLICT
-        @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.NOT_IN_CONFLICT
+        @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.IN_CONFLICT
     end
 end
 
-@testset "test_farkas_dual_min" begin
+function test_IIS_Two_conflicting_constraints_GreaterThan_LessThan()
+    model = Xpress.Optimizer(OUTPUTLOG = 0)
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+    b1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(0.0))
+    b2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [y]), 0.0), MOI.GreaterThan(0.0))
+    cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
+    c1 = MOI.add_constraint(model, cf1, MOI.LessThan(-1.0))
+    cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]), 0.0)
+    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+
+    # Getting the results before the conflict refiner has been called must return an error.
+    @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
+    @test_throws ErrorException MOI.get(model, MOI.ConstraintConflictStatus(), c1)
+
+    # Once it's called, no problem.
+    # Two possible IISes: b1, b2, c1 OR b2, c1, c2
+    MOI.compute_conflict!(model)
+    @test MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), b1) in [MOI.IN_CONFLICT, MOI.NOT_IN_CONFLICT]
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), b2) == MOI.IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) in [MOI.IN_CONFLICT, MOI.NOT_IN_CONFLICT]
+end
+
+function test_IIS_Two_conflicting_constraints_EqualTo()
+    model = Xpress.Optimizer(OUTPUTLOG = 0)
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+    b1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(0.0))
+    b2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [y]), 0.0), MOI.GreaterThan(0.0))
+    cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
+    c1 = MOI.add_constraint(model, cf1, MOI.EqualTo(-1.0))
+    cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]), 0.0)
+    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+
+    # Getting the results before the conflict refiner has been called must return an error.
+    @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
+    @test_throws ErrorException MOI.get(model, MOI.ConstraintConflictStatus(), c1)
+
+    # Once it's called, no problem.
+    # Two possible IISes: b1, b2, c1 OR b2, c1, c2
+    MOI.compute_conflict!(model)
+    @test MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), b1) in [MOI.IN_CONFLICT, MOI.NOT_IN_CONFLICT]
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), b2) == MOI.IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) in [MOI.IN_CONFLICT, MOI.NOT_IN_CONFLICT]
+end
+
+function test_IIS_Variables_outside_conflict()
+    model = Xpress.Optimizer(OUTPUTLOG = 0)
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+    z = MOI.add_variable(model)
+    b1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(0.0))
+    b2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [y]), 0.0), MOI.GreaterThan(0.0))
+    b3 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [z]), 0.0), MOI.GreaterThan(0.0))
+    cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
+    c1 = MOI.add_constraint(model, cf1, MOI.LessThan(-1.0))
+    cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0, 1.0], [x, y, z]), 0.0)
+    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+
+    # Getting the results before the conflict refiner has been called must return an error.
+    @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
+    @test_throws ErrorException MOI.get(model, MOI.ConstraintConflictStatus(), c1)
+
+    # Once it's called, no problem.
+    MOI.compute_conflict!(model)
+    @test MOI.get(model, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), b1) == MOI.IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), b2) == MOI.IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), b3) == MOI.NOT_IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.NOT_IN_CONFLICT
+end
+
+function test_IIS_No_conflict()
+    model = Xpress.Optimizer(OUTPUTLOG = 0)
+    x = MOI.add_variable(model)
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(1.0))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.LessThan(2.0))
+
+    # Getting the results before the conflict refiner has been called must return an error.
+    @test MOI.get(model, MOI.ConflictStatus()) == MOI.COMPUTE_CONFLICT_NOT_CALLED
+    @test_throws ErrorException MOI.get(model, MOI.ConstraintConflictStatus(), c1)
+
+    # Once it's called, no problem.
+    MOI.compute_conflict!(model)
+    @test MOI.get(model, MOI.ConflictStatus()) == MOI.NO_CONFLICT_FOUND
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.NOT_IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.NOT_IN_CONFLICT
+end
+
+function test_farkas_dual_min()
     model = Xpress.Optimizer(OUTPUTLOG = 0, PRESOLVE = 0)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(
         model,
-        MOI.ObjectiveFunction{MOI.SingleVariable}(),
-        MOI.SingleVariable(x[1]),
+        MOI.ObjectiveFunction{MOI.VariableIndex}(),
+        x[1],
     )
     clb = MOI.add_constraint.(
-        model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0)
+        model, x, MOI.GreaterThan(0.0)
     )
     c = MOI.add_constraint(
         model,
@@ -310,17 +201,17 @@ end
     @test clb_dual[2] ≈ -c_dual atol = 1e-6
 end
 
-@testset "test_farkas_dual_min_interval" begin
+function test_farkas_dual_min_interval()
     model = Xpress.Optimizer(OUTPUTLOG = 0, PRESOLVE = 0)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(
         model,
-        MOI.ObjectiveFunction{MOI.SingleVariable}(),
-        MOI.SingleVariable(x[1]),
+        MOI.ObjectiveFunction{MOI.VariableIndex}(),
+        x[1],
     )
     clb = MOI.add_constraint.(
-        model, MOI.SingleVariable.(x), MOI.Interval(0.0, 10.0)
+        model, x, MOI.Interval(0.0, 10.0)
     )
     c = MOI.add_constraint(
         model,
@@ -339,16 +230,16 @@ end
     @test clb_dual[2] ≈ -c_dual atol = 1e-6
 end
 
-@testset "test_farkas_dual_min_equalto" begin
+function test_farkas_dual_min_equalto()
     model = Xpress.Optimizer(OUTPUTLOG = 0, PRESOLVE = 0)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(
         model,
-        MOI.ObjectiveFunction{MOI.SingleVariable}(),
-        MOI.SingleVariable(x[1]),
+        MOI.ObjectiveFunction{MOI.VariableIndex}(),
+        x[1],
     )
-    clb = MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.EqualTo(0.0))
+    clb = MOI.add_constraint.(model, x, MOI.EqualTo(0.0))
     c = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 1.0], x), 0.0),
@@ -366,7 +257,7 @@ end
     @test clb_dual[2] ≈ -c_dual atol = 1e-6
 end
 
-@testset "test_farkas_dual_min_ii" begin
+function test_farkas_dual_min_ii()
     model = Xpress.Optimizer(OUTPUTLOG = 0, PRESOLVE = 0)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
@@ -376,7 +267,7 @@ end
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(-1.0, x[1])], 0.0),
     )
     clb = MOI.add_constraint.(
-        model, MOI.SingleVariable.(x), MOI.LessThan(0.0)
+        model, x, MOI.LessThan(0.0)
     )
     c = MOI.add_constraint(
         model,
@@ -395,17 +286,17 @@ end
     @test clb_dual[2] ≈ c_dual atol = 1e-6
 end
 
-@testset "test_farkas_dual_max" begin
+function test_farkas_dual_max()
     model = Xpress.Optimizer(OUTPUTLOG = 0, PRESOLVE = 0)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(
         model,
-        MOI.ObjectiveFunction{MOI.SingleVariable}(),
-        MOI.SingleVariable(x[1]),
+        MOI.ObjectiveFunction{MOI.VariableIndex}(),
+        x[1],
     )
     clb = MOI.add_constraint.(
-        model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0)
+        model, x, MOI.GreaterThan(0.0)
     )
     c = MOI.add_constraint(
         model,
@@ -424,7 +315,7 @@ end
     @test clb_dual[2] ≈ -c_dual atol = 1e-6
 end
 
-@testset "test_farkas_dual_max_ii" begin
+function test_farkas_dual_max_ii()
     model = Xpress.Optimizer(OUTPUTLOG = 0, PRESOLVE = 0)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
@@ -434,7 +325,7 @@ end
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(-1.0, x[1])], 0.0),
     )
     clb = MOI.add_constraint.(
-        model, MOI.SingleVariable.(x), MOI.LessThan(0.0)
+        model, x, MOI.LessThan(0.0)
     )
     c = MOI.add_constraint(
         model,
@@ -453,7 +344,7 @@ end
     @test clb_dual[2] ≈ c_dual atol = 1e-6
 end
 
-@testset "Delete equality constraint in binary variable" begin
+function test_Delete_equality_constraint_in_binary_variable()
     atol = rtol = 1e-6
     model = Xpress.Optimizer(OUTPUTLOG = 0)
     # an example on mixed integer programming
@@ -475,16 +366,16 @@ end
 
     vc1 = MOI.add_constraint(
         model,
-        MOI.SingleVariable(v[1]),
+        v[1],
         MOI.Interval(0.0, 5.0),
     )
     vc2 = MOI.add_constraint(
         model,
-        MOI.SingleVariable(v[2]),
+        v[2],
         MOI.Interval(0.0, 10.0),
     )
-    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[2]), MOI.Integer())
-    vc4 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.ZeroOne())
+    vc3 = MOI.add_constraint(model, v[2], MOI.Integer())
+    vc4 = MOI.add_constraint(model, v[3], MOI.ZeroOne())
 
     objf =
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.1, 2.0, 5.0], v), 0.0)
@@ -517,7 +408,7 @@ end
     MOI.delete(model, vc4)
 
     # Fix z to its optimal value
-    vc5 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.EqualTo(z_value))
+    vc5 = MOI.add_constraint(model, v[3], MOI.EqualTo(z_value))
 
     MOI.optimize!(model)
 
@@ -536,7 +427,7 @@ end
     @test MOI.get(model, MOI.ObjectiveBound()) >= 19.4 - atol
 
     # Add back binary bounds to z
-    vc4 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.ZeroOne())
+    vc4 = MOI.add_constraint(model, v[3], MOI.ZeroOne())
 
     # Remove equality constraint
     MOI.delete(model, vc5)
@@ -556,31 +447,35 @@ end
     @test MOI.get(model, MOI.ObjectiveBound()) >= 19.4 - atol
 end
 
-@testset "Binary Variables Infeasibility" begin
+function test_Binary_Variables_Infeasibility()
     atol = rtol = 1e-6
     model = Xpress.Optimizer(OUTPUTLOG = 0)
     v = MOI.add_variable(model)
 
     infeas_err = ErrorException("The problem is infeasible")
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v), MOI.ZeroOne())
+    vc1 = MOI.add_constraint(model, v, MOI.ZeroOne())
     @test_throws infeas_err vc2 = MOI.add_constraint(
         model,
-        MOI.SingleVariable(v),
+        v,
         MOI.GreaterThan(2.0),
     )
     @test_throws infeas_err vc3 = MOI.add_constraint(
         model,
-        MOI.SingleVariable(v),
+        v,
         MOI.LessThan(-1.0),
         )
     @test_throws infeas_err vc4 = MOI.add_constraint(
         model,
-        MOI.SingleVariable(v),
+        v,
         MOI.Interval(-1.0,-0.5),
     )
     @test_throws infeas_err vc5 = MOI.add_constraint(
         model,
-        MOI.SingleVariable(v),
+        v,
         MOI.EqualTo(2.0),
     )
 end
+
+end
+
+TestMOIWrapper.runtests()

--- a/test/MathOptInterface/MOI_callbacks.jl
+++ b/test/MathOptInterface/MOI_callbacks.jl
@@ -4,10 +4,6 @@ using Random
 using Test
 
 const MOI = MathOptInterface
-const MOIT = MathOptInterface.Test
-
-const MOIT = MOI.Test
-const MOIU = MOI.Utilities
 
 function callback_simple_model()
     model = Xpress.Optimizer(
@@ -43,7 +39,7 @@ function callback_knapsack_model()
 
     N = 30
     x = MOI.add_variables(model, N)
-    MOI.add_constraints(model, MOI.SingleVariable.(x), MOI.ZeroOne())
+    MOI.add_constraints(model, x, MOI.ZeroOne())
     MOI.set.(model, MOI.VariablePrimalStart(), x, 0.0)
     Random.seed!(1)
     item_weights, item_values = rand(N), rand(N)

--- a/test/SemiContInt/semicontint.jl
+++ b/test/SemiContInt/semicontint.jl
@@ -1,4 +1,4 @@
-function semiconttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
+function semiconttest(model::MOI.ModelLike, config::MOIT.Config{T}) where T
     atol = config.atol
     rtol = config.rtol
 
@@ -148,7 +148,7 @@ function semiconttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
     end
 end
 
-function semiinttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
+function semiinttest(model::MOI.ModelLike, config::MOIT.Config{T}) where T
     atol = config.atol
     rtol = config.rtol
 


### PR DESCRIPTION
- The new `test/MathOptInterface/MOI_Wrapper.jl` tests are all passed except some conflict tests that need further investigation
- The old `test/MathOptInterface/MOI_Wrapper.jl` is renamed as `test/MOI_Wrapper_legacy.jl` to wipe out old `MOI.Test` related tests and keep handwritten tests. `test/MathOptInterface/MOI_Wrapper.jl` tests are all passed.
- Some of `test/MathOptInterface/MOI_callbacks.jl` tests failed. @joaquimg Would you like to have a look?
- I tried to solve #127 by using `XPRSaddmipsol` to set up initial value of variables but I am not sure about the correctness.