### PR TITLE
Fix issue #127 (Xpress ignore warm starts). 

### DIFF
--- a/test/MathOptInterface/MOI_Wrapper.jl
+++ b/test/MathOptInterface/MOI_Wrapper.jl
@@ -668,7 +668,6 @@ end
     MOI.set(model, MOI.RawParameter("MAXNODE"), 1)
 
     MOI.optimize!(model)
-    @show model.callback_state
 
     # One node may not be enough to even get any solution.
     if MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT


### PR DESCRIPTION
See https://github.com/jump-dev/Xpress.jl/issues/127

The code is extensively commented. I am up to adding more comments if deemed necessary, or writing some test (but not sure if the one I have written is adequate for unit testing).

The code I used to test the change follows. It is the original MRE but changed to be a little more challenging so heuristics does not immediately solve it. Also, I only add the MIP-start of the non-zero values because I noticed that, initially, the code only worked if every variable had a start value. To fix this problem (allow incomplete initialization) I needed to do some index juggling and create `_map_original_idxs_to_presolve_idxs!` (this works even if the solver is not in presolved state).

```julia
using JuMP, Xpress, StableRNGs

rng = StableRNGs.StableRNG(42)
weight = rand(rng, 20:1000, 100)
profit = weight .- (5,)
capacity = 10000
model = Model()
@variable(model, x[1:length(weight)], Bin)
## Objective: maximize profit
@objective(model, Max, profit' * x)
## Constraint: can carry all
@constraint(model, weight' * x <= capacity)

# Start with Xpress
set_optimizer(model, Xpress.Optimizer)
set_optimizer_attribute(model, "OUTPUTLOG", 1)
set_optimizer_attribute(model, "logfile", "output.log")

# Find the solution, initialise the optimal solution in the JuMP model,
# and run it again.
optimize!(model)
first_solve_values = value.(x)
@show sum(first_solve_values .* profit)
#set_start_value.(all_variables(model), first_solve_values)
nz_values_idxs = findall(v -> isapprox(v, 1.0; atol = 1e-4), first_solve_values)
@show nz_values_idxs
@show first_solve_values[nz_values_idxs]
set_start_value.(
    x[nz_values_idxs],
    first_solve_values[nz_values_idxs]
)
optimize!(model)
```

The `output.log` file follows:

```
FICO Xpress v8.12.3, Community, solve started 1:13:32, Sep 30, 2021
Heap usage: 108KB (peak 108KB, 468KB system)
Maximizing MILP  with these control settings:
OUTPUTLOG = 1
MPSNAMELENGTH = 64
CALLBACKFROMMASTERTHREAD = 1
Original problem has:
         1 rows          100 cols          100 elements       100 globals
Presolved problem has:
         1 rows           97 cols           97 elements        97 globals
LP relaxation tightened
Presolve finished in 0 seconds
Heap usage: 145KB (peak 175KB, 471KB system)

Coefficient range                    original                 solved        
  Coefficients   [min,max] : [ 2.50e+01,  9.98e+02] / [ 4.88e-02,  1.95e+00]
  RHS and bounds [min,max] : [ 1.00e+00,  1.00e+04] / [ 1.00e+00,  1.95e+01]
  Objective      [min,max] : [ 2.00e+01,  9.93e+02] / [ 2.00e+01,  9.93e+02]
Autoscaling applied standard scaling

Will try to keep branch and bound tree memory usage below 13.6GB
 *** Solution found:      .000000   Time:   0    Heuristic: T ***
 *** Solution found:  9869.000000   Time:   0    Heuristic: e ***
Starting concurrent solve with dual

 Concurrent-Solve,   0s
            Dual        
    objective   dual inf
 D  9946.5158   .0000000
------- optimal --------
Concurrent statistics:
      Dual: 1 simplex iterations, 0.00s
Optimal solution found
 
   Its         Obj Value      S   Ninf  Nneg   Sum Dual Inf  Time
     1       9946.515837      D      0     0        .000000     0
Dual solved problem
  1 simplex iterations in 0.00 seconds at time 0

Final objective                       : 9.946515837104072e+03
  Max primal violation      (abs/rel) :       0.0 /       0.0
  Max dual violation        (abs/rel) :       0.0 /       0.0
  Max complementarity viol. (abs/rel) :       0.0 /       0.0

Starting root cutting & heuristics
 
 Its Type    BestSoln    BestBound   Sols    Add    Del     Gap     GInf   Time
a         9883.000000  9946.515837      3                  0.64%       0      0
q         9920.000000  9946.515837      4                  0.27%       0      0
a         9927.000000  9945.000000      5                  0.18%       0      0
   1  K   9927.000000  9945.000000      5      1      0    0.18%       1      0
   2  K   9927.000000  9945.000000      5      3      0    0.18%       2      0
   3  K   9927.000000  9945.000000      5      6      0    0.18%       5      0
b         9931.000000  9945.000000      6                  0.14%       0      0
   4  K   9931.000000  9945.000000      6     10      6    0.14%       2      0
   5  K   9931.000000  9945.000000      6     13      9    0.14%       6      0
   6  K   9931.000000  9945.000000      6     13     12    0.14%       6      0
   7  K   9931.000000  9945.000000      6     13     12    0.14%       6      0
   8  K   9931.000000  9945.000000      6     12     13    0.14%       6      0
   9  K   9931.000000  9945.000000      6      6     12    0.14%       8      0
R         9933.000000  9945.000000      7                  0.12%       0      0
R         9940.000000  9945.000000      8                  0.05%       0      0
  10  K   9940.000000  9945.000000      8      8      7    0.05%       7      0
  11  K   9940.000000  9945.000000      8     14      8    0.05%       6      0
  12  K   9940.000000  9945.000000      8     15     13    0.05%       8      0
  13  K   9940.000000  9945.000000      8      0     14    0.05%       9      0
  14  G   9940.000000  9945.000000      8      5      0    0.05%       9      0
  15  G   9940.000000  9945.000000      8      6     14    0.05%       6      0
Heuristic search 'R' started
R         9941.000000  9945.000000      9                  0.04%       0      0
Heuristic search 'R' stopped
 
Cuts in the matrix         : 5
Cut elements in the matrix : 152

Performing root presolve...

Reduced problem has:       6 rows      69 columns       221 elements
Presolve dropped   :       0 rows      28 columns        28 elements
Will try to keep branch and bound tree memory usage below 13.6GB
 
   Its         Obj Value      S   Ninf  Nneg   Sum Dual Inf  Time
    43       9946.515837      D      0     0        .000000     0
Optimal solution found
Dual solved problem
  43 simplex iterations in 0.00 seconds at time 0

Final objective                       : 9.946515837104072e+03
  Max primal violation      (abs/rel) :       0.0 /       0.0
  Max dual violation        (abs/rel) :       0.0 /       0.0
  Max complementarity viol. (abs/rel) :       0.0 /       0.0

Starting root cutting & heuristics
 
 Its Type    BestSoln    BestBound   Sols    Add    Del     Gap     GInf   Time
   1  K   9941.000000  9945.000000      9     10      3    0.04%       2      0
   2  K   9941.000000  9945.000000      9     16     26    0.04%       4      0
Heuristic search 'R' started
Heuristic search 'R' stopped
 
Cuts in the matrix         : 2
Cut elements in the matrix : 103
Will try to keep branch and bound tree memory usage below 12.1GB

Starting tree search.
Deterministic mode with up to 8 running threads and up to 16 tasks.
Heap usage: 3018KB (peak 10MB, 616KB system)
 
    Node     BestSoln    BestBound   Sols Active  Depth     Gap     GInf   Time
       1  9941.000000  9945.000000      9      2      1    0.04%       3      0
       2  9941.000000  9945.000000      9      2      3    0.04%       4      0
       3  9941.000000  9945.000000      9      2      3    0.04%       3      0
       4  9941.000000  9945.000000      9      2      4    0.04%       3      0
       5  9941.000000  9945.000000      9      2      4    0.04%       2      0
       6  9941.000000  9945.000000      9      2      5    0.04%       2      0
       7  9941.000000  9945.000000      9      5      5    0.04%       5      0
E      7  9943.000000  9945.000000     10      8      3    0.02%       0      0
       8  9943.000000  9945.000000     10      8      6    0.02%       2      0
       9  9943.000000  9945.000000     10      8      6    0.02%       2      0
      10  9943.000000  9945.000000     10      8      4    0.02%       3      0
a     13  9945.000000  9945.000000     11      8      8   -0.00%       0      0
STOPPING - MIPRELSTOP target reached (MIPRELSTOP=0.0001  gap=-1.82905e-16).
      21  9945.000000  9945.000000     11      3      1   -0.00%       1      0
STOPPING - MIPRELSTOP target reached (MIPRELSTOP=0.0001  gap=-1.82905e-16).
 *** Search completed ***
Uncrunching matrix
Final MIP objective                   : 9.945000000000000e+03
Final MIP bound                       : 9.944999999999998e+03
  Solution time / primaldual integral :         0s/  1.573648%
  Number of solutions found / nodes   :        11 /        21
  Max primal violation      (abs/rel) :       0.0 /       0.0
  Max integer violation     (abs    ) :       0.0
User solution (_) stored.
FICO Xpress v8.12.3, Community, solve started 1:13:34, Sep 30, 2021
Heap usage: 2385KB (peak 11MB, 607KB system)
Maximizing MILP  with these control settings:
OUTPUTLOG = 1
MPSNAMELENGTH = 64
CALLBACKFROMMASTERTHREAD = 1
Original problem has:
         1 rows          100 cols          100 elements       100 globals
Presolved problem has:
         1 rows           97 cols           97 elements        97 globals
LP relaxation tightened
Presolve finished in 0 seconds
Heap usage: 2425KB (peak 11MB, 607KB system)

Coefficient range                    original                 solved        
  Coefficients   [min,max] : [ 2.50e+01,  9.98e+02] / [ 4.88e-02,  1.95e+00]
  RHS and bounds [min,max] : [ 1.00e+00,  1.00e+04] / [ 1.00e+00,  1.95e+01]
  Objective      [min,max] : [ 2.00e+01,  9.93e+02] / [ 2.00e+01,  9.93e+02]
Autoscaling applied standard scaling

Will try to keep branch and bound tree memory usage below 11.8GB
Starting concurrent solve with dual

 Concurrent-Solve,   0s
            Dual        
    objective   dual inf
 D  9946.5158   .0000000
------- optimal --------
Concurrent statistics:
      Dual: 0 simplex iterations, 0.00s
Optimal solution found
 
   Its         Obj Value      S   Ninf  Nneg   Sum Dual Inf  Time
     0       9946.515837      D      0     0        .000000     0
Dual solved problem
  0 simplex iterations in 0.00 seconds at time 0

Final objective                       : 9.946515837104072e+03
  Max primal violation      (abs/rel) :       0.0 /       0.0
  Max dual violation        (abs/rel) :       0.0 /       0.0
  Max complementarity viol. (abs/rel) :       0.0 /       0.0

Starting root cutting & heuristics
 
 Its Type    BestSoln    BestBound   Sols    Add    Del     Gap     GInf   Time
User solution (_) searched: Found feasible solution through local search.
U         9945.000000  9946.515837      1                  0.02%       0      0

Performing root presolve...

Reduced problem has:       1 rows      19 columns        19 elements
Presolve dropped   :       0 rows      78 columns        78 elements
Will try to keep branch and bound tree memory usage below 11.8GB
 
   Its         Obj Value      S   Ninf  Nneg   Sum Dual Inf  Time
     0       18535.00000      D      1     0        .000000     0
     1       9946.515837      D      0     0        .000000     0
Optimal solution found
Dual solved problem
  1 simplex iterations in 0.00 seconds at time 0

Final objective                       : 9.946515837104072e+03
  Max primal violation      (abs/rel) :       0.0 /       0.0
  Max dual violation        (abs/rel) :       0.0 /       0.0
  Max complementarity viol. (abs/rel) :       0.0 /       0.0

Starting root cutting & heuristics
 
 Its Type    BestSoln    BestBound   Sols    Add    Del     Gap     GInf   Time
 *** Search completed ***
Uncrunching matrix
Final MIP objective                   : 9.945000000000000e+03
Final MIP bound                       : 9.945000000000000e+03
  Solution time / primaldual integral :         0s/ 47.215492%
  Number of solutions found / nodes   :         1 /         1
  Max primal violation      (abs/rel) :       0.0 /       0.0
  Max integer violation     (abs    ) :       0.0
``` 

The most important excerpt of the log above is:

```
User solution (_) searched: Found feasible solution through local search.
U         9945.000000  9946.515837      1                  0.02%       0      0
```

Which shows that the Xpress correctly MIP-starts the model with an incomplete (only non-zeros) solution.

I have run the tests after the change and all of them pass.

![2021-09-30-00:42:38_1920x1080](https://user-images.githubusercontent.com/14113435/135386874-bc21a426-9b35-4a72-bac3-cefdc4fb8a92.png)
