### PR TITLE
Fix error message

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -165,8 +165,8 @@ function getlicerrmsg(; len = 1024)
     buffer = Array{Cchar}(undef, len*8)
     buffer_p = pointer(buffer)
     GC.@preserve buffer begin
-        Lib.XPRSgetlicerrmsg(msg, len)
-        return unsafe_string(msg)
+        Lib.XPRSgetlicerrmsg(buffer_p, len)
+        return unsafe_string(buffer_p)
     end
 end
 


### PR DESCRIPTION
Msg variable is undefined. The proper variable that should be passed is Buffer_p.