### PR TITLE
add method for MOI.EqualTo{Float64} set

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -1484,18 +1484,10 @@ function MOI.delete(
     return
 end
 
-function _fix_variable_value(model, info, value)
-    Lib.XPRSchgbounds(model.inner, Cint(1), Ref(Cint(info.column-1)), Ref(UInt8('B')), Ref(value))
-    info.previous_lower_bound = _get_variable_lower_bound(model, info)
-    info.previous_upper_bound = _get_variable_upper_bound(model, info)
-    return
-end
-
 """
     _set_variable_lower_bound(model, info, value)
 
 This function is used to indirectly set the lower bound of a variable.
-    MathOptInterface.EqualTo{Float64}
 We need to do it this way to account for potential lower bounds of 0.0 added by
 VectorOfVariables-in-SecondOrderCone constraints.
 
@@ -1689,7 +1681,11 @@ function MOI.set(
     lower, upper = _bounds(s)
     @assert lower == upper
     info = _info(model, c)
-    _fix_variable_value(model, info, lower)
+    # expects vectors as input
+    # B is used to indicate that both bounds are fixed to the value. B indicates a change in both bounds, i.e. the column is fixed.
+    Lib.XPRSchgbounds(model.inner, Cint(1), Ref(Cint(info.column-1)), Ref(Cchar('B')), Ref(value))
+    info.previous_lower_bound = _get_variable_lower_bound(model, info)
+    info.previous_upper_bound = _get_variable_upper_bound(model, info)
     return
 end
 

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -1683,7 +1683,7 @@ function MOI.set(
     info = _info(model, c)
     # expects vectors as input
     # B is used to indicate that both bounds are fixed to the value. B indicates a change in both bounds, i.e. the column is fixed.
-    Lib.XPRSchgbounds(model.inner, Cint(1), Ref(Cint(info.column-1)), Ref(Cchar('B')), Ref(value))
+    Lib.XPRSchgbounds(model.inner, Cint(1), Ref(Cint(info.column-1)), Ref(UInt8('B')), Ref(lower))
     info.previous_lower_bound = _get_variable_lower_bound(model, info)
     info.previous_upper_bound = _get_variable_upper_bound(model, info)
     return

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -1683,7 +1683,14 @@ function MOI.set(
     info = _info(model, c)
     # expects vectors as input
     # B is used to indicate that both bounds are fixed to the value. B indicates a change in both bounds, i.e. the column is fixed.
-    Lib.XPRSchgbounds(model.inner, Cint(1), Ref(Cint(info.column-1)), Ref(UInt8('B')), Ref(lower))
+    if info.num_soc_constraints == 0
+        Lib.XPRSchgbounds(model.inner, Cint(1), Ref(Cint(info.column-1)), Ref(UInt8('B')), Ref(lower))
+    else
+    # If the model contains SoC constraints, _set_variable_lower_bound needs to execute
+    # additional checks
+        _set_variable_lower_bound(model, info, lower)
+        _set_variable_upper_bound(model, info, upper)
+    end
     info.previous_lower_bound = _get_variable_lower_bound(model, info)
     info.previous_upper_bound = _get_variable_upper_bound(model, info)
     return


### PR DESCRIPTION
The previous implementation called `Lib.XPRSchgbounds(), Ref(value))` twice once for L and once for B. This implied that when calling `JuMP.fix()` Xpress would throw warnings if a previous UB or LB was above or below the new value. In large model it would generate a lot of noise in the logging. 

This PR employs `Lib.XPRSchgbounds(model.inner, Cint(1), Ref(Cint(info.column-1)), Ref(UInt8('B')), Ref(value))` in a new method for attempts to fix the variable and remove the warning calls. 