### PR TITLE
Remove calls to src/api.jl

### DIFF
--- a/src/MOI/MOI_callbacks.jl
+++ b/src/MOI/MOI_callbacks.jl
@@ -305,7 +305,7 @@ function MOI.submit(
     if ilength == MOI.get(model, MOI.NumberOfVariables())
         mipsolcol = C_NULL
     end
-    addmipsol(model_cb, ilength, mipsolval, mipsolcol, C_NULL)
+    @checked Lib.XPRSaddmipsol(model_cb, ilength, mipsolval, mipsolcol, C_NULL)
     return MOI.HEURISTIC_SOLUTION_UNKNOWN
 end
 MOI.supports(::Optimizer, ::MOI.HeuristicSolution{CallbackData}) = true

--- a/src/Xpress.jl
+++ b/src/Xpress.jl
@@ -49,7 +49,7 @@ const XPRS_ATTRIBUTES = Dict{String,Any}(
 function initialize()
     Libdl.dlopen(libxprs)
     userlic()
-    init()
+    Lib.XPRSinit(C_NULL)
     # Calling free is not necessary since destroyprob is called
     # in the finalizer.
     return

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -76,7 +76,7 @@ mutable struct XpressProblem <: CWrapper
     )
         model = new(ptr, logfile)
         if finalize_env
-            finalizer(destroyprob, model)
+            finalizer(Lib.XPRSdestroyprob, model)
         end
         return model
     end

--- a/src/license.jl
+++ b/src/license.jl
@@ -81,7 +81,7 @@ function userlic(;
     slicmsg = path_lic #xpauth_path == "dh" ? Array{Cchar}(undef, 1024*8) :
 
     # FIRST call do xprslicense to get BASE LIC
-    license(lic, slicmsg)
+    Lib.XPRSlicense(lic, slicmsg)
 
     # convert BASE LIC to GIVEN LIC
     lic = liccheck(lic)
@@ -90,7 +90,7 @@ function userlic(;
     buffer = Array{Cchar}(undef, 1024 * 8)
     buffer_p = pointer(buffer)
     ierr = GC.@preserve buffer begin
-        license(lic, Cstring(buffer_p))
+        Lib.XPRSlicense(lic, Cstring(buffer_p))
     end
 
     # check LIC TYPE

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,18 +16,9 @@ end
 @testset "Xpress tests" begin
     prob = Xpress.XpressProblem()
     @test Xpress.getcontrol(prob, "HEURTHREADS") == 0
-    vXpress_major = Int(Xpress.get_version().major)
-    file_extension = ifelse(vXpress_major <= 38, ".mps", "")
-    msg = "Xpress internal error:\n\n85 Error: File not found: $(file_extension).\n"
+    r = Xpress.Lib.XPRSreadprob(prob, "", "")
     if Xpress.get_version() >= v"41.0.0"
-        @test_throws(
-            Xpress.XpressError(85, msg),
-            Xpress.Lib.XPRSreadprob(prob, "", ""),
-        )
-    else
-        @test_throws(
-            Xpress.XpressError(32, msg),
-            Xpress.Lib.XPRSreadprob(prob, "", ""),
-        )
+        msg = "Xpress internal error:\n\n85 Error: File not found: .\n"
+        @test_throws Xpress.XpressError(85, msg) Xpress._check(prob, r)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ end
     msg = "Xpress internal error:\n\n85 Error: File not found: $(file_extension).\n"
     if Xpress.get_version() >= v"41.0.0"
         @test_throws(
-            Xpress.XpressError(85, msg)
+            Xpress.XpressError(85, msg),
             Xpress.Lib.XPRSreadprob(prob, "", ""),
         )
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,8 +20,14 @@ end
     file_extension = ifelse(vXpress_major <= 38, ".mps", "")
     msg = "Xpress internal error:\n\n85 Error: File not found: $(file_extension).\n"
     if Xpress.get_version() >= v"41.0.0"
-        @test_throws Xpress.XpressError(85, msg) Xpress.readprob(prob, "", "")
+        @test_throws(
+            Xpress.XpressError(85, msg)
+            Xpress.Lib.XPRSreadprob(prob, "", ""),
+        )
     else
-        @test_throws Xpress.XpressError(32, msg) Xpress.readprob(prob, "", "")
+        @test_throws(
+            Xpress.XpressError(32, msg),
+            Xpress.Lib.XPRSreadprob(prob, "", ""),
+        )
     end
 end


### PR DESCRIPTION
We don't have to remove it for a while, but I'd like the code to not call `src/api.jl`.