### PR TITLE
Simplify _indices_and_coefficients to return 0-indexed cols

### DIFF
--- a/src/MOI/MOI_callbacks.jl
+++ b/src/MOI/MOI_callbacks.jl
@@ -194,7 +194,7 @@ function MOI.submit(
         [rhs - f.constant],         # drhs
         Cint[0, length(indices)],   # mstart
         mindex,
-        Cint.(indices .- 1),        # mcols
+        indices,                    # mcols
         coefficients,
     )
     @checked Lib.XPRSloadcuts(cb.callback_data.model, 1, Cint(-1), 1, mindex)
@@ -238,7 +238,7 @@ function MOI.submit(
         [rhs - f.constant],         # drhs
         Cint[0, length(indices)],   # mstart
         mindex,
-        Cint.(indices .- 1),        # mcols
+        indices,                    # mcols
         coefficients,
     )
     @checked Lib.XPRSloadcuts(cb.callback_data.model, 1, Cint(-1), 1, mindex)

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -1205,7 +1205,7 @@ function MOI.set(
         _indices_and_coefficients(model, f)
     obj = zeros(length(model.variable_info))
     for (i, c) in zip(affine_indices, affine_coefficients)
-        obj[i] = c
+        obj[i+1] = c
     end
     @checked Lib.XPRSchgmqobj(model.inner, length(I), I, J, V)
     model.objective_type = SCALAR_QUADRATIC

--- a/test/test_MOI_wrapper.jl
+++ b/test/test_MOI_wrapper.jl
@@ -1906,6 +1906,28 @@ function test_callback_function_replace()
     return
 end
 
+function test_add_constraints_scalar_function_constant_not_zero()
+    model = Xpress.Optimizer()
+    x = MOI.add_variables(model, 2)
+    f, s = 1.0 .* x .+ 2.0, MOI.EqualTo.([0.0, 0.0])
+    @test_throws(
+        MOI.ScalarFunctionConstantNotZero{Float64,eltype(f),eltype(s)},
+        MOI.add_constraints(model, f, s),
+    )
+    return
+end
+
+function test_quadratic_scalar_function_constant_not_zero()
+    model = Xpress.Optimizer()
+    x = MOI.add_variable(model)
+    f, s = 1.0 * x * x + 2.0, MOI.EqualTo(0.0)
+    @test_throws(
+        MOI.ScalarFunctionConstantNotZero{Float64,typeof(f),typeof(s)},
+        MOI.add_constraint(model, f, s),
+    )
+    return
+end
+
 end  # TestMOIWrapper
 
 TestMOIWrapper.runtests()


### PR DESCRIPTION
We were previously doing lots of unnecessary `- 1` and `Cint.()`.