### PR TITLE
Prep for v0.17.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Xpress"
 uuid = "9e70acf3-d6c9-5be6-b5bd-4e2c73e3e054"
 authors = ["Joaquim Dias Garcia <joaquim@psr-inc.com>, Dheepak Krishnamurthy <me@kdheepak.com>, Jose Daniel Lara <jdlara@berkeley.edu>"]
 url = "https://github.com/jump-dev/Xpress.jl"
-version = "0.16.2"
+version = "0.17.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
I'm open to a discussion on whether this should be v0.16.3 or v0.17.0.

The argument for v0.17.0 is that it is a rather large change: https://github.com/jump-dev/Xpress.jl/compare/v0.16.2...master

The main breakage risks are #257 and #259.

 * #259 is breaking for anyone using the `64(` functions in `Lib` (but they were probably already broken because of the wrong type?)
 * #257 has one breakage, removing https://github.com/jump-dev/Xpress.jl/blob/ceb9df83ff254db8684be77966ffd350321e07b8/src/Lib/xprs.jl#L2366-L2394 You now must explicitly call `XPRSgetmipentities` or `XPRSgetglobal`, but this shouldn affect only people hacking at the C API.

I've also moved a bunch of unused stuff to `src/api.jl` which was never tested, so there's a risk I made a mistake during the refactoring that wasn't caught because of the lack of tests.

## TODO

 - [ ] Get @joaquimg to test internally