### PR TITLE
Remove mention of community license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,29 +83,18 @@ By using Xpress_jll, you agree to certain license conditions. See the
 [Xpress_jll.jl README](https://github.com/jump-dev/Xpress_jll.jl/tree/master?tab=readme-ov-file#license)
 for more details.
 
-By default, `Xpress_jll` includes a limited size community license. If you have
-purchased a license for FICO Xpress, you should additionally set the
-`XPAUTH_PATH` environment variable to point to the directory of your license
-file.
-
 ```julia
 import Xpress_jll
 # This environment variable must be set _before_ loading Xpress.jl
 ENV["XPRESS_JL_LIBRARY"] = Xpress_jll.libxprs
-# Optional: point to the directory of your xpauth.xpr license file
-ENV["XPAUTH_PATH"] = "/path/to/directory"
+# Point to your xpauth.xpr license file
+ENV["XPAUTH_PATH"] = "/path/to/xpauth.xpr"
 using Xpress
 ```
 
 If you plan to use Xpress_jll, `Pkg.add("Xpress")` will fail because it cannot
 find a local installation of Xpress. Therefore, you should set
 `XPRESS_JL_SKIP_LIB_CHECK` before installing.
-
-The community license that is shipped with `Xpress_jll`, has an expiration date.
-If usage fails because of the community license expiration date, please update
-to more recent version of `Xpress_jll`. If an older version of `Xpress_jll` is
-required for reproducibility issues, you should obtain and manually specify a
-license via the `XPAUTH_PATH` environment variable.
 
 ## Use with JuMP
 


### PR DESCRIPTION
Since the license is now part of https://anaconda.org/fico-xpress/xpress and not https://anaconda.org/fico-xpress/xpresslibs.