### PR TITLE
update attribute controls for xpress-9.4

### DIFF
--- a/src/Lib/xprs.jl
+++ b/src/Lib/xprs.jl
@@ -3274,6 +3274,15 @@ const XPRS_BARALG = 8315
 
 const XPRS_SIFTING = 8319
 
+# Struct does not exist in v43
+const XPRS_TREEPRESOLVE = 8320
+
+# Struct does not exist in v43
+const XPRS_TREEPRESOLVE_KEEPBASIS = 8321
+
+# Struct does not exist in v43
+const XPRS_TREEPRESOLVEOPS = 8322
+
 const XPRS_LPLOGSTYLE = 8326
 
 const XPRS_RANDOMSEED = 8328
@@ -3402,6 +3411,15 @@ const XPRS_SIFTSWITCH = 8425
 # Struct does not exist in v33
 const XPRS_HEUREMPHASIS = 8427
 
+# Struct does not exist in v43
+const XPRS_COMPUTEMATX = 8428
+
+# Struct does not exist in v43
+const XPRS_COMPUTEMATX_IIS = 8429
+
+# Struct does not exist in v43
+const XPRS_COMPUTEMATX_IISMAXTIME = 8430
+
 # Struct does not exist in v33
 const XPRS_BARREFITER = 8431
 
@@ -3423,6 +3441,9 @@ const XPRS_IOTIMEOUT = 8442
 # Struct does not exist in v33
 const XPRS_AUTOCUTTING = 8446
 
+# Struct does not exist in v43
+const XPRS_GLOBALNUMINITNLPCUTS = 8449
+
 # Struct does not exist in v33
 const XPRS_CALLBACKCHECKTIMEDELAY = 8451
 
@@ -3434,6 +3455,9 @@ const XPRS_MULTIOBJLOG = 8458
 
 # Struct does not exist in v33
 const XPRS_BACKGROUNDMAXTHREADS = 8461
+
+# Struct does not exist in v43
+const XPRS_GLOBALLSHEURSTRATEGY = 8464
 
 # Struct does not exist in v33
 const XPRS_GLOBALSPATIALBRANCHIFPREFERORIG = 8465
@@ -3465,6 +3489,18 @@ const XPRS_BACKGROUNDSELECT = 8463
 
 # Struct does not exist in v33
 const XPRS_HEURSEARCHBACKGROUNDSELECT = 8477
+
+const XPRS_HEURSEARCHCOPYCONTROLS = 8480
+
+const XPRS_GLOBALNLPCUTS = 8481
+
+const XPRS_GLOBALTREENLPCUTS = 8482
+
+const XPRS_BARHGOPS = 8483
+
+const XPRS_BARHMAXRESTARTS = 8484
+
+const XPRS_MCFCUTSTRATEGY = 8486
 
 const XPRS_MATRIXNAME = 3001
 
@@ -3609,6 +3645,8 @@ const XPRS_MIPTHREADID = 1037
 
 const XPRS_ALGORITHM = 1049
 
+const XPRS_CROSSOVERITER = 1051
+
 # Struct does not exist in v33
 const XPRS_SOLSTATUS = 1053
 
@@ -3726,6 +3764,10 @@ const XPRS_GLOBALNLPINFEAS = 1403
 
 # Struct does not exist in v33
 const XPRS_IISSOLSTATUS = 1406
+
+const XPRS_INPUTROWS = 1408
+
+const XPRS_INPUTCOLS = 1409
 
 const XPRS_BARITER = 5001
 

--- a/src/attributes_controls.jl
+++ b/src/attributes_controls.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Joaquim Garcia, and contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 #=
 
 File automatically generated with script:
@@ -16,7 +21,7 @@ Banner from header (xprs.h):
 
 =#
 
-const STRING_CONTROLS = Dict{String, Int32}(
+const STRING_CONTROLS = Dict{String,Int32}(
     "MPSRHSNAME" => 6001,
     "MPSOBJNAME" => 6002,
     "MPSRANGENAME" => 6003,
@@ -28,7 +33,7 @@ const STRING_CONTROLS = Dict{String, Int32}(
     "COMPUTEEXECSERVICE" => 6022,
 )
 
-const DOUBLE_CONTROLS = Dict{String, Int32}(
+const DOUBLE_CONTROLS = Dict{String,Int32}(
     "MAXCUTTIME" => 8149,
     "MAXSTALLTIME" => 8443,
     "TUNERMAXTIME" => 8364,
@@ -115,7 +120,7 @@ const DOUBLE_CONTROLS = Dict{String, Int32}(
     "BARHGEXTRAPOLATE" => 7166,
 )
 
-const INTEGER_CONTROLS = Dict{String, Int32}(
+const INTEGER_CONTROLS = Dict{String,Int32}(
     "EXTRAROWS" => 8004,
     "EXTRACOLS" => 8005,
     "LPITERLIMIT" => 8007,
@@ -386,7 +391,7 @@ const INTEGER_CONTROLS = Dict{String, Int32}(
     "HEURSEARCHBACKGROUNDSELECT" => 8477,
 )
 
-const STRING_ATTRIBUTES = Dict{String, Int32}(
+const STRING_ATTRIBUTES = Dict{String,Int32}(
     "MATRIXNAME" => 3001,
     "BOUNDNAME" => 3002,
     "OBJNAME" => 3003, # kept for compatibility
@@ -396,7 +401,7 @@ const STRING_ATTRIBUTES = Dict{String, Int32}(
     "UUID" => 3011,
 )
 
-const DOUBLE_ATTRIBUTES = Dict{String, Int32}(
+const DOUBLE_ATTRIBUTES = Dict{String,Int32}(
     "MIPSOLTIME" => 1371,
     "TIME" => 1122,
     "LPOBJVAL" => 2001,
@@ -431,7 +436,7 @@ const DOUBLE_ATTRIBUTES = Dict{String, Int32}(
     "BARCGAP" => 4005,
 )
 
-const INTEGER_ATTRIBUTES = Dict{String, Int32}(
+const INTEGER_ATTRIBUTES = Dict{String,Int32}(
     "ROWS" => 1001,
     "SETS" => 1004,
     "PRIMALINFEAS" => 1007,

--- a/src/attributes_controls.jl
+++ b/src/attributes_controls.jl
@@ -1,27 +1,22 @@
-# Copyright (c) 2016: Joaquim Garcia, and contributors
-#
-# Use of this source code is governed by an MIT-style license that can be found
-# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
-
 #=
 
 File automatically generated with script:
 Xpress.jl/scripts/build_param_control_dicts.jl
 
-Last build: 2023-04-05T15:30:42.197
+Last build: 2024-07-31T21:27:17.533
 
-Optimizer version: 41.1.3
+Optimizer version: 43.1.1
 
 Banner from lib:
 ###
 
 Banner from header (xprs.h):
- * (c) Copyright Fair Isaac Corporation 1983-2023. All rights reserved     *
- * For FICO Xpress Optimizer v41.01.03                                     *
+ * (c) Copyright Fair Isaac Corporation 1983-2024. All rights reserved     *
+ * For FICO Xpress Optimizer v43.01.01                                     *
 
 =#
 
-const STRING_CONTROLS = Dict{String,Int32}(
+const STRING_CONTROLS = Dict{String, Int32}(
     "MPSRHSNAME" => 6001,
     "MPSOBJNAME" => 6002,
     "MPSRANGENAME" => 6003,
@@ -33,7 +28,7 @@ const STRING_CONTROLS = Dict{String,Int32}(
     "COMPUTEEXECSERVICE" => 6022,
 )
 
-const DOUBLE_CONTROLS = Dict{String,Int32}(
+const DOUBLE_CONTROLS = Dict{String, Int32}(
     "MAXCUTTIME" => 8149,
     "MAXSTALLTIME" => 8443,
     "TUNERMAXTIME" => 8364,
@@ -111,13 +106,16 @@ const DOUBLE_CONTROLS = Dict{String,Int32}(
     "MIPRESTARTFACTOR" => 7145,
     "BAROBJPERTURB" => 7146,
     "CPIALPHA" => 7149,
+    "GLOBALSPATIALBRANCHPROPAGATIONEFFORT" => 7152,
+    "GLOBALSPATIALBRANCHCUTTINGEFFORT" => 7153,
     "GLOBALBOUNDINGBOX" => 7154,
     "TIMELIMIT" => 7158,
     "SOLTIMELIMIT" => 7159,
     "REPAIRINFEASTIMELIMIT" => 7160,
+    "BARHGEXTRAPOLATE" => 7166,
 )
 
-const INTEGER_CONTROLS = Dict{String,Int32}(
+const INTEGER_CONTROLS = Dict{String, Int32}(
     "EXTRAROWS" => 8004,
     "EXTRACOLS" => 8005,
     "LPITERLIMIT" => 8007,
@@ -217,6 +215,7 @@ const INTEGER_CONTROLS = Dict{String,Int32}(
     "BRANCHCHOICE" => 8162,
     "BARREGULARIZE" => 8163,
     "SBSELECT" => 8164,
+    "IISLOG" => 8165,
     "LOCALCHOICE" => 8170,
     "LOCALBACKTRACK" => 8171,
     "DUALSTRATEGY" => 8174,
@@ -267,6 +266,7 @@ const INTEGER_CONTROLS = Dict{String,Int32}(
     "MIPRAMPUP" => 8255,
     "MAXLOCALBACKTRACK" => 8257,
     "USERSOLHEURISTIC" => 8258,
+    "PRECONVERTOBJTOCONS" => 8260,
     "FORCEPARALLELDUAL" => 8265,
     "BACKTRACKTIE" => 8266,
     "BRANCHDISJ" => 8267,
@@ -287,14 +287,14 @@ const INTEGER_CONTROLS = Dict{String,Int32}(
     "CORESPERCPU" => 8296,
     "RESOURCESTRATEGY" => 8297,
     "CLAMPING" => 8301,
-    "SLEEPONTHREADWAIT" => 8302,
+    "SLEEPONTHREADWAIT" => 8302, # kept for compatibility
     "PREDUPROW" => 8307,
     "CPUPLATFORM" => 8312,
     "BARALG" => 8315,
     "SIFTING" => 8319,
-    "TREEPRESOLVE" => 8320, # Not in v38, kept for backwards compatibility.
-    "TREEPRESOLVE_KEEPBASIS" => 8321, # Not in v38, kept for backwards compatibility.
-    "TREEPRESOLVEOPS" => 8322, # Not in v38, kept for backwards compatibility.
+    "TREEPRESOLVE" => 8320, # kept for compatibility
+    "TREEPRESOLVE_KEEPBASIS" => 8321, # kept for compatibility
+    "TREEPRESOLVEOPS" => 8322, # kept for compatibility
     "LPLOGSTYLE" => 8326,
     "RANDOMSEED" => 8328,
     "TREEQCCUTS" => 8331,
@@ -322,7 +322,7 @@ const INTEGER_CONTROLS = Dict{String,Int32}(
     "TUNERVERBOSE" => 8370,
     "TUNEROUTPUT" => 8372,
     "PREANALYTICCENTER" => 8374,
-    "NETCUTS" => 8382,
+    "NETCUTS" => 8382, # kept for compatibility
     "LPFLAGS" => 8385,
     "MIPKAPPAFREQ" => 8386,
     "OBJSCALEFACTOR" => 8387,
@@ -349,9 +349,9 @@ const INTEGER_CONTROLS = Dict{String,Int32}(
     "OUTPUTCONTROLS" => 8424,
     "SIFTSWITCH" => 8425,
     "HEUREMPHASIS" => 8427,
-    "COMPUTEMATX" => 8428,
-    "COMPUTEMATX_IIS" => 8429,
-    "COMPUTEMATX_IISMAXTIME" => 8430,
+    "COMPUTEMATX" => 8428, # kept for compatibility
+    "COMPUTEMATX_IIS" => 8429, # kept for compatibility
+    "COMPUTEMATX_IISMAXTIME" => 8430, # kept for compatibility
     "BARREFITER" => 8431,
     "COMPUTELOG" => 8434,
     "SIFTPRESOLVEOPS" => 8435,
@@ -360,18 +360,33 @@ const INTEGER_CONTROLS = Dict{String,Int32}(
     "IOTIMEOUT" => 8442,
     "MAXSTALLTIME" => 8443, # kept for compatibility
     "AUTOCUTTING" => 8446,
+    "GLOBALNUMINITNLPCUTS" => 8449,
     "CALLBACKCHECKTIMEDELAY" => 8451,
     "MULTIOBJOPS" => 8457,
     "MULTIOBJLOG" => 8458,
+    "BACKGROUNDMAXTHREADS" => 8461,
+    "GLOBALLSHEURSTRATEGY" => 8464,
     "GLOBALSPATIALBRANCHIFPREFERORIG" => 8465,
     "PRECONFIGURATION" => 8470,
     "FEASIBILITYJUMP" => 8471,
+    "IISOPS" => 8472,
+    "RLTCUTS" => 8476,
+    "ALTERNATIVEREDCOSTS" => 8478,
+    "HEURSHIFTPROP" => 8479,
+    "HEURSEARCHCOPYCONTROLS" => 8480,
+    "GLOBALNLPCUTS" => 8481,
+    "GLOBALTREENLPCUTS" => 8482,
+    "BARHGOPS" => 8483,
+    "BARHGMAXRESTARTS" => 8484,
+    "MCFCUTSTRATEGY" => 8486,
     "EXTRAELEMS" => 8006,
     "EXTRAPRESOLVE" => 8037, # kept for compatibility
     "EXTRASETELEMS" => 8191,
+    "BACKGROUNDSELECT" => 8463,
+    "HEURSEARCHBACKGROUNDSELECT" => 8477,
 )
 
-const STRING_ATTRIBUTES = Dict{String,Int32}(
+const STRING_ATTRIBUTES = Dict{String, Int32}(
     "MATRIXNAME" => 3001,
     "BOUNDNAME" => 3002,
     "OBJNAME" => 3003, # kept for compatibility
@@ -381,7 +396,7 @@ const STRING_ATTRIBUTES = Dict{String,Int32}(
     "UUID" => 3011,
 )
 
-const DOUBLE_ATTRIBUTES = Dict{String,Int32}(
+const DOUBLE_ATTRIBUTES = Dict{String, Int32}(
     "MIPSOLTIME" => 1371,
     "TIME" => 1122,
     "LPOBJVAL" => 2001,
@@ -416,7 +431,7 @@ const DOUBLE_ATTRIBUTES = Dict{String,Int32}(
     "BARCGAP" => 4005,
 )
 
-const INTEGER_ATTRIBUTES = Dict{String,Int32}(
+const INTEGER_ATTRIBUTES = Dict{String, Int32}(
     "ROWS" => 1001,
     "SETS" => 1004,
     "PRIMALINFEAS" => 1007,
@@ -445,6 +460,7 @@ const INTEGER_ATTRIBUTES = Dict{String,Int32}(
     "BRANCHVAR" => 1036,
     "MIPTHREADID" => 1037,
     "ALGORITHM" => 1049,
+    "CROSSOVERITER" => 1051,
     "SOLSTATUS" => 1053,
     "TIME" => 1122, # kept for compatibility
     "ORIGINALROWS" => 1124,
@@ -477,6 +493,7 @@ const INTEGER_ATTRIBUTES = Dict{String,Int32}(
     "CORESDETECTED" => 1260,
     "PHYSICALCORESDETECTED" => 1261,
     "PHYSICALCORESPERCPUDETECTED" => 1262,
+    "OPTIMIZETYPEUSED" => 1268,
     "BARSING" => 1281,
     "BARSINGR" => 1282,
     "PRESOLVEINDEX" => 1284,
@@ -496,6 +513,9 @@ const INTEGER_ATTRIBUTES = Dict{String,Int32}(
     "SOLVEDOBJS" => 1399,
     "OBJSTOSOLVE" => 1400,
     "GLOBALNLPINFEAS" => 1403,
+    "IISSOLSTATUS" => 1406,
+    "INPUTROWS" => 1408,
+    "INPUTCOLS" => 1409,
     "BARITER" => 5001,
     "BARDENSECOL" => 5004,
     "BARCROSSOVER" => 5005,


### PR DESCRIPTION
Ran the `build_param_control_dicts.jl` script and kept old parameters for compatibility.

Closes #272 