### PR TITLE
Skip failing test due to upstream bug

### DIFF
--- a/test/test_MOI_wrapper.jl
+++ b/test/test_MOI_wrapper.jl
@@ -57,6 +57,8 @@ function test_runtests()
         model,
         MOI.Test.Config(; atol = 1e-3, rtol = 1e-3);
         exclude = [
+            # An upstream bug in Xpress@9.7.0
+            "test_solve_conflict_bound_bound",
             # tested with PRESOLVE=0 below
             "_SecondOrderCone_",
             "test_constraint_PrimalStart_DualStart_SecondOrderCone",


### PR DESCRIPTION
Failed https://github.com/jump-dev/MathOptInterface.jl/pull/2828. Upstream test is https://github.com/jump-dev/MathOptInterface.jl/blob/0001bcdc1a12ea01944f9f3c84b6cb573e6b5b5d/src/Test/test_solve.jl#L882-L900
I thought it was a new test, but it's old, so this must be a new bug in v9.7.0.

I wrote FICO:

This LP file reports XPRS_SOLSTATUS_OPTIMAL when it should be infeasible

```
shell> cat /tmp/model.lp
\Written from user model (presolvestate=0x4c06e1)
\Problem name:                                                                  
\FICO Xpress v9.7.0, Community, written 15:18:15, Sep 3, 2025

Minimize
__OBJ___: 0 C1

Subject To

Bounds
2 <= C1 <= 1 

End
```

I can reproduce via the C API:

```julia
julia> using Xpress: Lib

julia> p_prob = Ref{Ptr{Cvoid}}(C_NULL)
Base.RefValue{Ptr{Nothing}}(Ptr{Nothing} @0x0000000000000000)

julia> Lib.XPRScreateprob(p_prob)
0

julia> prob = p_prob[]
Ptr{Nothing} @0x0000000140048010

julia> Lib.XPRSaddcols(prob, 1, 0, [0.0], Cint[0], C_NULL, C_NULL, [2.0], [1.0])
0

julia> Lib.XPRSwriteprob(prob, "/tmp/xprs_bug.lp", "")
0

julia> solvestatus, solstatus = Ref{Cint}(0), Ref{Cint}(0)
(Base.RefValue{Int32}(0), Base.RefValue{Int32}(0))

julia> Lib.XPRSoptimize(prob, "", solvestatus, solstatus)
0

julia> solvestatus, solstatus
(Base.RefValue{Int32}(3), Base.RefValue{Int32}(1))

julia> solvestatus[] == Lib.XPRS_SOLVESTATUS_COMPLETED
true

julia> solstatus[] == Lib.XPRS_SOLSTATUS_OPTIMAL
true

julia> Lib.XPRSdestroyprob(prob)
0

shell> cat /tmp/xprs_bug.lp
\Written from user model (presolvestate=0x480061)
\Problem name:                                                                  
\FICO Xpress v9.7.0, Community, written 15:29:18, Sep 3, 2025

Minimize
__OBJ___: 0 C1

Subject To

Bounds
2 <= C1 <= 1 

End
```

And here it is from JuMP:
```julia
julia> using JuMP, Xpress
[ Info: Xpress: Found license file /Users/odow/git/jump-dev/Xpress/xpauth.xpr
[ Info: Xpress: Development license detected.

julia> model = Model(Xpress.Optimizer)
A JuMP Model
├ solver: Xpress
├ objective_sense: FEASIBILITY_SENSE
├ num_variables: 0
├ num_constraints: 0
└ Names registered in the model: none

julia> @variable(model, 2 <= x <= 1)
x

julia> optimize!(model)
?475 Warning: Inconsistent bounds [2,1] for column C1 in call to XPRSchgbounds
FICO Xpress v9.7.0, Community, solve started 15:25:27, Sep 3, 2025
Heap usage: 137KB (peak 137KB, 126KB system)
Minimizing LP  using up to 10 threads and up to 32GB memory, with these control settings:
OUTPUTLOG = 1
MPSNAMELENGTH = 64
CALLBACKFROMMASTERTHREAD = 1
Original problem has:
         0 rows            1 cols            0 elements
Presolved problem has:
         0 rows            1 cols            0 elements
Presolve finished in 0 seconds
Heap usage: 137KB (peak 150KB, 126KB system)

Coefficient range                    original                 solved        
  Coefficients   [min,max] : [      0.0,       0.0] / [      0.0,       0.0]
  RHS and bounds [min,max] : [ 1.00e+00,  2.00e+00] / [ 1.00e+00,  2.00e+00]
  Objective      [min,max] : [      0.0,       0.0] / [      0.0,       0.0]
Autoscaling applied standard scaling

 
   Its         Obj Value      S   Ninf  Nneg   Sum Dual Inf  Time
     0           .000000      D      0     0        .000000     0
Refining primal/dual infeasibility of 1.000e+00 /       0.0
     0           .000000      D      0     0        .000000     0
     0           .000000      D      0     0        .000000     0
Uncrunching matrix
Refining primal/dual infeasibility of 1.000e+00 /       0.0
     0           .000000      D      1     0        .000000     0
     0           .000000      D      0     0        .000000     0
Optimal solution found
Dual solved problem
  0 simplex iterations in 0.00 seconds at time 0

Final objective                       : 0.000000000000000e+00
  Max primal violation      (abs/rel) : 1.000e+00 / 1.000e+00
  Max dual violation        (abs/rel) :       0.0 /       0.0
  Max complementarity viol. (abs/rel) :       0.0 /       0.0

julia> solution_summary(model)
solution_summary(; result = 1, verbose = false)
├ solver_name          : Xpress
├ Termination
│ ├ termination_status : OPTIMAL
│ ├ result_count       : 1
│ ├ raw_status         : 1 Optimal ( XPRS_LP_OPTIMAL). - no interruption - the solve completed normally
│ └ objective_bound    : 0.00000e+00
├ Solution (result = 1)
│ ├ primal_status        : FEASIBLE_POINT
│ ├ dual_status          : FEASIBLE_POINT
│ ├ objective_value      : 0.00000e+00
│ ├ dual_objective_value : 0.00000e+00
│ └ relative_gap         : NaN
└ Work counters
  └ solve_time (sec)   : 5.48291e-03
```