### PR TITLE
Skip another failing upstream test

### DIFF
--- a/test/test_MOI_wrapper.jl
+++ b/test/test_MOI_wrapper.jl
@@ -59,6 +59,7 @@ function test_runtests()
         exclude = [
             # An upstream bug in Xpress@9.7.0
             "test_solve_conflict_bound_bound",
+            "test_solve_conflict_invalid_interval",
             # tested with PRESOLVE=0 below
             "_SecondOrderCone_",
             "test_constraint_PrimalStart_DualStart_SecondOrderCone",


### PR DESCRIPTION
I have no idea why solver-tests failed, but #288 didn't?

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/17447800163/job/49546283645#step:14:920